### PR TITLE
Add M2 documentation deliverables

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,41 +28,43 @@ Relaycode is an intuitive extrinsics builder designed to transform the way devel
 - Polkadot Integration: [Dedot](https://github.com/dedotdev/dedot)
 - Theming: next-themes for dark/light mode support
 
+## Documentation
+
+- [API Reference](docs/api/README.md) - Core encoding, decoding, and validation APIs
+- [Component Reference](docs/components/README.md) - Input component documentation
+- [Getting Started Tutorial](docs/tutorial/getting-started.md) - Build your first extrinsic
+- [Advanced Usage](docs/tutorial/advanced.md) - Bi-directional editing, batch calls, complex types
+- [Testing Guide](docs/testing-guide.md) - How to run and write tests
+
 ## Milestones
 
 For detailed project milestones and deliverables, see our [Milestones](docs/relaycode.md) documentation.
 
-### List of components for Extrinsic Inputs (WIP)
+### Implemented Input Components
 
-This is a list of input components that are going to be implemented for the extrinsic builder. This list is currently based on `polkadot-js` components found [here](https://github.com/polkadot-js/apps/tree/master/packages/react-params/src/Param). 
+The following input components have been implemented for the extrinsic builder:
 
-- [ ] **Account** - Handles `AccountId`, `Address`, `LookupSource`, `MultiAddress`
-- [ ] **Amount** - Handles `AccountIndex`, `i8`, `i16`, `i32`, `i64`, `i128`, `u8`, `u16`, `u32`, `u64`, `u128`, `u256`
-- [ ] **Balance** - Handles `Amount`, `Balance`, `BalanceOf`
-- [ ] **Bool** - Handles `bool`
-- [ ] **Bytes** - Handles `Bytes`, `Vec<u8>`
-- [ ] **Call** - Handles `Call`, `Proposal`, `RuntimeCall`
-- [ ] **Cid** - Handles `PalletAllianceCid`
-- [ ] **Code** - Handles `Code`
-- [ ] **DispatchError** - Handles `DispatchError`
-- [ ] **DispatchResult** - Handles `DispatchResult`, `Result<Null, SpRuntimeDispatchError>`
-- [ ] **Raw** - Handles `Raw`, `RuntimeSessionKeys`, `Keys`
-- [ ] **Enum** - Handles `Enum`
-- [ ] **Hash256** - Handles `Hash`, `H256`
+- [x] **Account** - Handles `AccountId`, `Address`, `LookupSource`, `MultiAddress`
+- [x] **Amount** - Handles `i8`, `i16`, `i32`, `i64`, `i128`, `u8`, `u16`, `u32`, `u64`, `u128`, `Compact<uN>`
+- [x] **Balance** - Handles `Balance`, `BalanceOf`
+- [x] **Bool** - Handles `bool`
+- [x] **Bytes** - Handles `Bytes`, `Vec<u8>`
+- [x] **Call** - Handles `Call`, `RuntimeCall`
+- [x] **Enum** - Handles enum types from metadata
+- [x] **Hash256** - Handles `Hash`, `H256`
+- [x] **KeyValue** - Handles `KeyValue`
+- [x] **Moment** - Handles `Moment`, `MomentOf`
+- [x] **Option** - Handles `Option<T>`
+- [x] **Text** - Handles `String`, `Text` (and fallback for unknown types)
+- [x] **Struct** - Handles composite/struct types
+- [x] **Tuple** - Handles tuple types `(T1, T2, ...)`
+- [x] **Vector** - Handles `Vec<T>`, `BoundedVec<T, S>`
+- [x] **Vote** - Handles `Vote`
+- [x] **VoteThreshold** - Handles `VoteThreshold`
+
+### Planned Components
+
 - [ ] **Hash160** - Handles `H160`
 - [ ] **Hash512** - Handles `H512`
-- [ ] **KeyValue** - Handles `KeyValue`
-- [ ] **KeyValueArray** - Handles `Vec<KeyValue>`
-- [ ] **Moment** - Handles `Moment`, `MomentOf`
-- [ ] **Null** - Handles `Null`
-- [ ] **OpaqueCall** - Handles `OpaqueCall`
-- [ ] **Option** - Handles `Option`
-- [ ] **Text** - Handles `String`, `Text`
-- [ ] **Struct** - Handles `Struct`
-- [ ] **Tuple** - Handles `Tuple`
 - [ ] **BTreeMap** - Handles `BTreeMap`
-- [ ] **Vector** - Handles `Vec`, `BTreeSet`
-- [ ] **VectorFixed** - Handles `VecFixed`
-- [ ] **Vote** - Handles `Vote`
-- [ ] **VoteThreshold** - Handles `VoteThreshold`
-- [ ] **Unknown** - Handles `Unknown`
+- [ ] **VectorFixed** - Handles fixed-length arrays

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,93 @@
+# API Reference
+
+This documentation covers the core APIs used in Relaycode for building, encoding, decoding, and validating Substrate extrinsics.
+
+## Core Modules
+
+### [Codec API](./codec.md)
+Encoding and decoding functions for converting between form values and SCALE-encoded hex data.
+
+- `encodeArg()` - Encode a single value to hex
+- `decodeArg()` - Decode hex to a form value
+- `encodeAllArgs()` - Bulk encode all extrinsic arguments
+- `decodeAllArgs()` - Bulk decode concatenated argument hex
+
+### [Validation API](./validation.md)
+Input validation utilities for form fields and complex types.
+
+- `validateAllArgs()` - Validate all extrinsic arguments
+- `validateField()` - Validate a single field by type
+- `validateAmount()` - Numeric amount validation
+- `isValidAddressFormat()` - SS58 address format check
+- `isValidHexFormat()` - Hex string format check
+
+### [Parser API](./parser.md)
+Metadata parsing utilities for working with Dedot client metadata.
+
+- `createSectionOptions()` - Generate pallet options from metadata
+- `createMethodOptions()` - Generate method options for a pallet
+- `getArgType()` - Retrieve type information for arguments
+
+### [Input Map API](./input-map.md)
+Type resolution system for mapping Substrate types to UI components.
+
+- `findComponent()` - Find the appropriate input component for a type
+- Priority-based pattern matching
+- Custom type handler registration
+
+## Architecture
+
+Relaycode uses [Dedot](https://github.com/dedotdev/dedot) as its Polkadot client library. All encoding/decoding operations leverage Dedot's codec registry, which provides type-safe SCALE encoding based on chain metadata.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Extrinsic Builder UI                      │
+├─────────────────────────────────────────────────────────────┤
+│  Input Components  │  Validation  │  Encoding/Decoding      │
+│  (params/inputs/)  │  (lib/)      │  (lib/codec.ts)         │
+├─────────────────────────────────────────────────────────────┤
+│                     Dedot Client                             │
+│            (metadata, registry, codecs)                      │
+├─────────────────────────────────────────────────────────────┤
+│                   Substrate Chain                            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Usage Pattern
+
+```typescript
+import { DedotClient } from "dedot";
+import { encodeArg, decodeArg, validateField } from "@/lib";
+
+// 1. Connect to chain
+const client = await DedotClient.new("wss://rpc.polkadot.io");
+
+// 2. Validate input
+const validation = validateField("Balance", "1000000000000", "amount");
+if (!validation.valid) {
+  console.error(validation.error);
+}
+
+// 3. Encode for submission
+const result = encodeArg(client, typeId, value);
+if (result.success) {
+  console.log("Encoded:", result.hex);
+}
+
+// 4. Decode for display
+const decoded = decodeArg(client, typeId, hex);
+if (decoded.success) {
+  console.log("Decoded:", decoded.value);
+}
+```
+
+## Type Safety
+
+All APIs are fully typed with TypeScript. The Dedot client provides chain-specific type information through its generic parameter:
+
+```typescript
+import { DedotClient } from "dedot";
+import { PolkadotApi } from "@dedot/chaintypes";
+
+const client: DedotClient<PolkadotApi> = await DedotClient.new("wss://rpc.polkadot.io");
+```

--- a/docs/api/codec.md
+++ b/docs/api/codec.md
@@ -1,0 +1,245 @@
+# Codec API
+
+The codec module (`lib/codec.ts`) provides functions for encoding form values to SCALE-encoded hex and decoding hex back to form values. All operations use the Dedot client's codec registry for type-safe encoding.
+
+## Types
+
+### EncodeResult
+
+```typescript
+type EncodeResult =
+  | { success: true; hex: string }
+  | { success: false; hex: "0x"; error: string };
+```
+
+### DecodeResult
+
+```typescript
+type DecodeResult =
+  | { success: true; value: unknown; bytesConsumed: number }
+  | { success: false; error: string };
+```
+
+### EncodeAllResult
+
+```typescript
+interface EncodeAllResult {
+  argResults: EncodeResult[];     // Individual results per argument
+  argHexes: string[];             // Individual hex strings
+  concatenated: string;           // Combined hex for all args
+  hasErrors: boolean;             // True if any encoding failed
+  errors: Map<string, string>;    // Field name -> error message
+}
+```
+
+### DecodeAllResult
+
+```typescript
+interface DecodeAllResult {
+  success: boolean;               // True if all decoding succeeded
+  values: Record<string, unknown> | null;  // Decoded values by field name
+  errors: Map<string, string>;    // Field name -> error message
+  totalBytesConsumed: number;     // Bytes consumed from input
+}
+```
+
+## Functions
+
+### encodeArg()
+
+Encode a single form value to hex using the field's typeId from metadata.
+
+```typescript
+function encodeArg(
+  client: DedotClient<any>,
+  typeId: number,
+  value: unknown
+): EncodeResult
+```
+
+**Parameters:**
+- `client` - Connected Dedot client instance
+- `typeId` - The type ID from chain metadata
+- `value` - The form value to encode (string, number, object, etc.)
+
+**Returns:** `EncodeResult` with success status and hex or error
+
+**Example:**
+```typescript
+import { encodeArg } from "@/lib/codec";
+
+// Encode a balance value
+const result = encodeArg(client, 6, "1000000000000");
+if (result.success) {
+  console.log(result.hex); // "0x0010a5d4e800"
+} else {
+  console.error(result.error);
+}
+
+// Encode an account address
+const accountResult = encodeArg(client, 0, "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+```
+
+**Notes:**
+- Form values (always strings) are automatically coerced to appropriate types (BigInt for numbers, boolean for "true"/"false")
+- The codec is resolved from the client's registry using the typeId
+
+### decodeArg()
+
+Decode hex back to a form value using the field's typeId from metadata.
+
+```typescript
+function decodeArg(
+  client: DedotClient<any>,
+  typeId: number,
+  hex: string
+): DecodeResult
+```
+
+**Parameters:**
+- `client` - Connected Dedot client instance
+- `typeId` - The type ID from chain metadata
+- `hex` - The hex string to decode (with 0x prefix)
+
+**Returns:** `DecodeResult` with success status, decoded value, and bytes consumed
+
+**Example:**
+```typescript
+import { decodeArg } from "@/lib/codec";
+
+// Decode a balance value
+const result = decodeArg(client, 6, "0x0010a5d4e800");
+if (result.success) {
+  console.log(result.value);         // "1000000000000"
+  console.log(result.bytesConsumed); // 16
+}
+```
+
+**Notes:**
+- BigInt values are automatically converted to strings for form compatibility
+- The `bytesConsumed` field indicates how many bytes were read from the input
+
+### encodeAllArgs()
+
+Encode all form arguments for an extrinsic, returning individual and concatenated results.
+
+```typescript
+function encodeAllArgs(
+  client: DedotClient<any>,
+  fields: readonly { name?: string; typeId: number }[],
+  formValues: Record<string, unknown>
+): EncodeAllResult
+```
+
+**Parameters:**
+- `client` - Connected Dedot client instance
+- `fields` - Array of field definitions with name and typeId
+- `formValues` - Object mapping field names to form values
+
+**Returns:** `EncodeAllResult` with per-field results and concatenated hex
+
+**Example:**
+```typescript
+import { encodeAllArgs } from "@/lib/codec";
+
+// Encode a transfer call's arguments
+const fields = [
+  { name: "dest", typeId: 113 },   // MultiAddress
+  { name: "value", typeId: 6 },    // Balance
+];
+
+const formValues = {
+  dest: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+  value: "1000000000000",
+};
+
+const result = encodeAllArgs(client, fields, formValues);
+
+if (!result.hasErrors) {
+  console.log(result.concatenated);  // Full args hex
+  console.log(result.argHexes);      // Individual hex per arg
+} else {
+  result.errors.forEach((error, field) => {
+    console.error(`${field}: ${error}`);
+  });
+}
+```
+
+### decodeAllArgs()
+
+Decode concatenated argument hex back to individual form values.
+
+```typescript
+function decodeAllArgs(
+  client: DedotClient<any>,
+  fields: readonly { name?: string; typeId: number }[],
+  hex: string
+): DecodeAllResult
+```
+
+**Parameters:**
+- `client` - Connected Dedot client instance
+- `fields` - Array of field definitions with name and typeId
+- `hex` - Concatenated arguments hex (with 0x prefix)
+
+**Returns:** `DecodeAllResult` with decoded values or errors
+
+**Example:**
+```typescript
+import { decodeAllArgs } from "@/lib/codec";
+
+// Decode transfer arguments from hex
+const fields = [
+  { name: "dest", typeId: 113 },
+  { name: "value", typeId: 6 },
+];
+
+const hex = "0x00d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0010a5d4e800";
+
+const result = decodeAllArgs(client, fields, hex);
+
+if (result.success) {
+  console.log(result.values);
+  // { dest: { type: "Id", value: "5GrwvaEF..." }, value: "1000000000000" }
+}
+```
+
+**Notes:**
+- Decodes sequentially, consuming bytes from the buffer
+- Validates that re-encoding produces the same bytes
+- Warns if there are remaining bytes after decoding all fields
+
+## Value Coercion
+
+The codec module automatically coerces form string values to types expected by Dedot codecs:
+
+| Form Value | Coerced Type |
+|------------|--------------|
+| `"true"` | `true` (boolean) |
+| `"false"` | `false` (boolean) |
+| `"12345"` | `12345n` (BigInt) |
+| Other strings | Unchanged |
+
+This allows form inputs (which always produce strings) to work seamlessly with the strongly-typed codec system.
+
+## Error Handling
+
+All functions return result objects rather than throwing exceptions. Check the `success` field before accessing values:
+
+```typescript
+const result = encodeArg(client, typeId, value);
+
+if (result.success) {
+  // Safe to use result.hex
+  submitTransaction(result.hex);
+} else {
+  // Handle error
+  showError(result.error);
+}
+```
+
+Common error scenarios:
+- Invalid type ID (not found in registry)
+- Value doesn't match expected type
+- Malformed hex string for decoding
+- Insufficient bytes for decoding

--- a/docs/api/input-map.md
+++ b/docs/api/input-map.md
@@ -1,0 +1,239 @@
+# Input Map API
+
+The input map module (`lib/input-map.ts`) provides a type resolution system that maps Substrate types to appropriate UI input components. It uses a priority-based pattern matching system to find the best component for each type.
+
+## Functions
+
+### findComponent()
+
+Find the appropriate input component for a Substrate type.
+
+```typescript
+function findComponent(
+  typeName: string,
+  typeId?: number
+): ParamComponentType & { typeId?: number }
+```
+
+**Parameters:**
+- `typeName` - The type name from metadata (e.g., "AccountId", "Balance", "Vec<u8>")
+- `typeId` - Optional type ID for complex types that need registry lookup
+
+**Returns:** Object containing:
+- `component` - The React component to render
+- `schema` - Zod validation schema for the type
+- `typeId` - The passed-through typeId (if provided)
+
+**Example:**
+```typescript
+import { findComponent } from "@/lib/input-map";
+
+// Simple type lookup
+const { component: AccountComponent } = findComponent("AccountId");
+// Returns: Account component
+
+// Complex type with typeId
+const { component: VectorComponent, typeId } = findComponent("Vec<Balance>", 123);
+// Returns: Vector component with typeId for nested type resolution
+
+// Unknown type falls back to Text
+const { component: TextComponent } = findComponent("SomeUnknownType");
+// Returns: Text component
+```
+
+## Type Resolution
+
+The system uses a priority-based registry to match types. Higher priority patterns are checked first.
+
+### Priority Order
+
+| Priority | Component | Patterns |
+|----------|-----------|----------|
+| 100 | Account | `AccountId`, `AccountId32`, `AccountId20`, `MultiAddress`, `Address`, `LookupSource`, `/^AccountId/`, `/^MultiAddress/` |
+| 95 | Balance | `Balance`, `BalanceOf`, `/^Balance/` |
+| 90 | Amount | `Compact<u128>`, `Compact<u64>`, `u128`, `u64`, `u32`, `u16`, `u8`, `i128`, `i64`, `i32`, `i16`, `i8`, `/Compact</` |
+| 85 | Boolean | `bool` |
+| 80 | Hash256 | `H256`, `Hash`, `/H256/`, `/Hash/` |
+| 75 | Bytes | `Bytes`, `Vec<u8>`, `/Bytes/` |
+| 70 | Call | `Call`, `RuntimeCall`, `/Call$/`, `/RuntimeCall>/` |
+| 65 | Moment | `Moment`, `/Moment/` |
+| 60 | Vote | `Vote`, `/^Vote$/` |
+| 55 | VoteThreshold | `VoteThreshold`, `/VoteThreshold/` |
+| 50 | KeyValue | `KeyValue`, `/KeyValue/` |
+| 45 | Option | `/^Option</` |
+| 40 | Vector | `/^Vec</`, `/^BoundedVec</` |
+| 38 | Tuple | `/^\(/`, `/^Tuple/` |
+| 35 | Struct | (no patterns - fallback for composite types) |
+| 30 | Enum | (no patterns - fallback for enum types) |
+| — | Text | (default fallback for unknown types) |
+
+### Pattern Matching
+
+Patterns can be:
+- **Exact strings**: `"AccountId"` matches only `"AccountId"`
+- **Regular expressions**: `/^AccountId/` matches `"AccountId"`, `"AccountIdOf"`, etc.
+
+The system checks patterns in priority order, returning the first match.
+
+**Example matches:**
+```typescript
+findComponent("AccountId");       // → Account (exact match, priority 100)
+findComponent("AccountIdOf<T>");  // → Account (regex match, priority 100)
+findComponent("Balance");         // → Balance (exact match, priority 95)
+findComponent("BalanceOf<T>");    // → Balance (regex match, priority 95)
+findComponent("Vec<u8>");         // → Bytes (exact match, priority 75)
+findComponent("Vec<AccountId>");  // → Vector (regex match, priority 40)
+findComponent("Option<Balance>"); // → Option (regex match, priority 45)
+findComponent("UnknownType");     // → Text (fallback)
+```
+
+## Component Registration
+
+Components are registered in the `registry` array with the following structure:
+
+```typescript
+interface ComponentRegistration {
+  component: React.ComponentType<any>;  // The React component
+  schema: any;                          // Zod validation schema
+  patterns: (string | RegExp)[];        // Matching patterns
+  priority: number;                     // Higher = checked first
+}
+```
+
+### Current Registry
+
+```typescript
+const registry: ComponentRegistration[] = [
+  {
+    component: Account,
+    schema: Account.schema,
+    patterns: ["AccountId", "AccountId32", "MultiAddress", /^AccountId/],
+    priority: 100,
+  },
+  {
+    component: Balance,
+    schema: Balance.schema,
+    patterns: ["Balance", "BalanceOf", /^Balance/],
+    priority: 95,
+  },
+  // ... more registrations
+];
+```
+
+## Usage in Components
+
+The input map is typically used when dynamically rendering extrinsic parameters:
+
+```typescript
+import { findComponent } from "@/lib/input-map";
+
+function ParameterInput({ field, client, onChange }) {
+  const { component: Component, schema } = findComponent(
+    field.typeName,
+    field.typeId
+  );
+
+  return (
+    <Component
+      client={client}
+      name={field.name}
+      label={field.name}
+      description={field.typeName}
+      typeId={field.typeId}
+      onChange={onChange}
+    />
+  );
+}
+```
+
+### With Complex Types
+
+For complex types like `Option<T>`, `Vec<T>`, or `Call`, the component uses the `typeId` to resolve nested types:
+
+```typescript
+// In Option component
+function Option({ typeId, client, children, ...props }) {
+  // If no children provided, resolve inner type from registry
+  const innerType = useMemo(() => {
+    if (children) return children;
+    if (!client || !typeId) return null;
+
+    const typeInfo = client.registry.findType(typeId);
+    // Extract inner type and find its component
+    const innerTypeId = typeInfo.typeDef.value.typeParam;
+    const innerTypeName = client.registry.findType(innerTypeId).path?.join("::");
+
+    return findComponent(innerTypeName, innerTypeId);
+  }, [children, client, typeId]);
+
+  // Render inner component
+}
+```
+
+## Extending the Registry
+
+To add support for a custom type:
+
+1. Create the input component:
+```typescript
+// components/params/inputs/my-custom.tsx
+import { z } from "zod";
+import type { ParamInputProps } from "../types";
+
+const schema = z.string();
+
+export function MyCustom({ name, label, onChange, ...props }: ParamInputProps) {
+  return (
+    <div>
+      {/* Your input UI */}
+    </div>
+  );
+}
+
+MyCustom.schema = schema;
+```
+
+2. Add to the registry in `lib/input-map.ts`:
+```typescript
+import { MyCustom } from "@/components/params/inputs/my-custom";
+
+const registry: ComponentRegistration[] = [
+  // Add before lower-priority entries
+  {
+    component: MyCustom,
+    schema: MyCustom.schema,
+    patterns: ["MyCustomType", /^MyCustom/],
+    priority: 85,  // Choose appropriate priority
+  },
+  // ... existing entries
+];
+```
+
+## Best Practices
+
+1. **Choose appropriate priority**: Higher priority for more specific types
+2. **Use exact strings for common types**: Faster matching than regex
+3. **Use regex for type families**: e.g., `/^AccountId/` for all AccountId variants
+4. **Provide meaningful fallbacks**: Unknown types fall back to Text input
+5. **Include validation schema**: Each component should export a Zod schema
+
+## Type Patterns Reference
+
+Common Substrate type patterns and their expected components:
+
+| Type | Component | Notes |
+|------|-----------|-------|
+| `AccountId`, `AccountId32` | Account | SS58 address input |
+| `MultiAddress` | Account | Supports Id, Index, Raw variants |
+| `Balance`, `BalanceOf<T>` | Balance | With denomination selector |
+| `Compact<u128>` | Amount | Integer input |
+| `u32`, `u64`, `u128` | Amount | Unsigned integers |
+| `bool` | Boolean | Toggle switch |
+| `H256`, `BlockHash` | Hash256 | 32-byte hex input |
+| `Vec<u8>`, `Bytes` | Bytes | Hex byte array |
+| `Vec<T>` | Vector | Dynamic array |
+| `Option<T>` | Option | Optional with toggle |
+| `(T1, T2, ...)` | Tuple | Positional elements |
+| `{ field: T }` | Struct | Named fields |
+| `enum { A, B }` | Enum | Variant selector |
+| `Call`, `RuntimeCall` | Call | Nested extrinsic |

--- a/docs/api/parser.md
+++ b/docs/api/parser.md
@@ -1,0 +1,256 @@
+# Parser API
+
+The parser module (`lib/parser.ts`) provides utilities for working with Dedot client metadata, enabling the extrinsic builder to dynamically generate pallet and method options from chain metadata.
+
+## Functions
+
+### createSectionOptions()
+
+Generate a list of pallet options from chain metadata.
+
+```typescript
+function createSectionOptions(
+  metadata: Metadata["latest"] | null
+): { text: string; value: number; docs: string[] }[] | null
+```
+
+**Parameters:**
+- `metadata` - The latest metadata from a Dedot client (`client.metadata.latest`)
+
+**Returns:** Array of pallet options sorted alphabetically by name, or `null` if metadata is unavailable
+
+**Example:**
+```typescript
+import { createSectionOptions } from "@/lib/parser";
+
+const client = await DedotClient.new("wss://rpc.polkadot.io");
+const sections = createSectionOptions(client.metadata.latest);
+
+// Returns array like:
+// [
+//   { value: 4, text: "Balances", docs: ["The Balances pallet provides..."] },
+//   { value: 0, text: "System", docs: ["The System pallet provides..."] },
+//   { value: 25, text: "Utility", docs: ["A utility pallet..."] },
+//   ...
+// ]
+
+// Use in a select/dropdown
+<Select>
+  {sections?.map(section => (
+    <SelectItem key={section.value} value={section.value.toString()}>
+      {section.text}
+    </SelectItem>
+  ))}
+</Select>
+```
+
+**Notes:**
+- Only returns pallets that have callable extrinsics (filters out pallets without `calls`)
+- Results are sorted alphabetically by pallet name
+- The `value` is the pallet index used for call encoding
+- The `docs` array contains pallet documentation from metadata
+
+### createMethodOptions()
+
+Generate a list of method options for a specific pallet.
+
+```typescript
+function createMethodOptions(
+  client: DedotClient<PolkadotApi>,
+  sectionIndex: number
+): { text: string; value: number }[] | null
+```
+
+**Parameters:**
+- `client` - Connected Dedot client instance
+- `sectionIndex` - The pallet index from `createSectionOptions`
+
+**Returns:** Array of method options, or `null` if pallet has no calls
+
+**Example:**
+```typescript
+import { createMethodOptions } from "@/lib/parser";
+
+// Get methods for the Balances pallet (index 4)
+const methods = createMethodOptions(client, 4);
+
+// Returns array like:
+// [
+//   { text: "transferAllowDeath", value: 0 },
+//   { text: "forceTransfer", value: 2 },
+//   { text: "transferKeepAlive", value: 3 },
+//   { text: "transferAll", value: 4 },
+//   ...
+// ]
+```
+
+**Notes:**
+- Uses the client's registry to resolve the calls enum type
+- The `value` is the method variant index used for call encoding
+- Method names are returned as-is from metadata (typically camelCase)
+
+### getArgType()
+
+Get detailed type information for a specific type ID.
+
+```typescript
+function getArgType(
+  client: DedotClient<PolkadotApi>,
+  typeId: number
+): TypeDef | { type: "Enum"; value: { members: EnumMember[] } }
+```
+
+**Parameters:**
+- `client` - Connected Dedot client instance
+- `typeId` - The type ID from metadata
+
+**Returns:** Type definition details, with expanded enum members for enum types
+
+**Example:**
+```typescript
+import { getArgType } from "@/lib/parser";
+
+// Get type info for MultiAddress (type ID 113)
+const typeInfo = getArgType(client, 113);
+
+// For an enum type, returns:
+// {
+//   type: "Enum",
+//   value: {
+//     members: [
+//       { name: "Id", fields: [{ typeId: 0, typeName: "AccountId" }], index: 0 },
+//       { name: "Index", fields: [{ typeId: 114, typeName: "AccountIndex" }], index: 1 },
+//       { name: "Raw", fields: [{ typeId: 14, typeName: "Vec<u8>" }], index: 2 },
+//       ...
+//     ]
+//   }
+// }
+```
+
+## Working with Method Fields
+
+To get the parameters for a specific method, you need to traverse the metadata:
+
+```typescript
+function getMethodFields(client, palletIndex, methodIndex) {
+  // Find the pallet
+  const pallet = client.metadata.latest.pallets.find(
+    p => p.index === palletIndex
+  );
+  if (!pallet?.calls) return [];
+
+  // Get the calls type ID
+  const callsTypeId = typeof pallet.calls === "number"
+    ? pallet.calls
+    : pallet.calls.typeId;
+
+  // Get the enum type definition
+  const palletCalls = client.registry.findType(callsTypeId);
+  if (palletCalls.typeDef.type !== "Enum") return [];
+
+  // Find the specific method variant
+  const method = palletCalls.typeDef.value.members.find(
+    m => m.index === methodIndex
+  );
+  if (!method) return [];
+
+  // Return the fields (parameters)
+  return method.fields.map((field, index) => ({
+    name: field.name || `arg${index}`,
+    typeId: field.typeId,
+    typeName: field.typeName || "",
+  }));
+}
+```
+
+**Example usage:**
+```typescript
+// Get parameters for Balances::transferKeepAlive
+const fields = getMethodFields(client, 4, 3);
+// [
+//   { name: "dest", typeId: 113, typeName: "MultiAddress" },
+//   { name: "value", typeId: 6, typeName: "Compact<Balance>" }
+// ]
+```
+
+## Integration Example
+
+Complete example showing how to build a pallet/method selector:
+
+```typescript
+import { useState, useMemo } from "react";
+import { createSectionOptions, createMethodOptions } from "@/lib/parser";
+
+function ExtrinsicSelector({ client }) {
+  const [selectedPallet, setSelectedPallet] = useState("");
+  const [selectedMethod, setSelectedMethod] = useState("");
+
+  // Get all pallets
+  const pallets = useMemo(() => {
+    if (!client?.metadata?.latest) return [];
+    return createSectionOptions(client.metadata.latest) || [];
+  }, [client]);
+
+  // Get methods for selected pallet
+  const methods = useMemo(() => {
+    if (!client || !selectedPallet) return [];
+    const palletIndex = parseInt(selectedPallet);
+    return createMethodOptions(client, palletIndex) || [];
+  }, [client, selectedPallet]);
+
+  // Reset method when pallet changes
+  useEffect(() => {
+    setSelectedMethod("");
+  }, [selectedPallet]);
+
+  return (
+    <div>
+      <Select value={selectedPallet} onValueChange={setSelectedPallet}>
+        {pallets.map(p => (
+          <SelectItem key={p.value} value={p.value.toString()}>
+            {p.text}
+          </SelectItem>
+        ))}
+      </Select>
+
+      {selectedPallet && (
+        <Select value={selectedMethod} onValueChange={setSelectedMethod}>
+          {methods.map(m => (
+            <SelectItem key={m.value} value={m.value.toString()}>
+              {m.text}
+            </SelectItem>
+          ))}
+        </Select>
+      )}
+    </div>
+  );
+}
+```
+
+## Metadata Structure
+
+Understanding the Dedot metadata structure helps when working with these APIs:
+
+```typescript
+client.metadata.latest = {
+  pallets: [
+    {
+      index: number,           // Pallet index
+      name: string,            // Pallet name (e.g., "Balances")
+      calls: number | { typeId: number },  // Calls type ID
+      docs: string[],          // Documentation
+      // ... other fields
+    },
+    // ...
+  ],
+  types: [...],  // Type registry
+};
+
+// Types are stored in the registry
+client.registry.findType(typeId) = {
+  path: string[],              // Type path (e.g., ["sp_runtime", "MultiAddress"])
+  params: TypeParam[],         // Generic parameters
+  typeDef: TypeDef,            // The type definition
+  docs: string[],              // Type documentation
+};
+```

--- a/docs/api/validation.md
+++ b/docs/api/validation.md
@@ -1,0 +1,309 @@
+# Validation API
+
+The validation module (`lib/validation.ts`) provides utilities for validating extrinsic builder form inputs. These functions handle common validation scenarios for Substrate types.
+
+## Types
+
+### ValidationResult
+
+```typescript
+interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+```
+
+### AllArgsValidationResult
+
+```typescript
+interface AllArgsValidationResult {
+  valid: boolean;
+  results: Map<string, ValidationResult>;  // Per-field results
+  errors: string[];                         // All error messages
+}
+```
+
+## Functions
+
+### validateAllArgs()
+
+Validate all arguments for an extrinsic call.
+
+```typescript
+function validateAllArgs(
+  client: unknown,
+  fields: { name?: string; typeName?: string; typeId?: number }[],
+  values: Record<string, unknown>
+): AllArgsValidationResult
+```
+
+**Parameters:**
+- `client` - Dedot client (reserved for future type-aware validation)
+- `fields` - Array of field definitions with name and type info
+- `values` - Object mapping field names to form values
+
+**Returns:** `AllArgsValidationResult` with overall validity and per-field results
+
+**Example:**
+```typescript
+import { validateAllArgs } from "@/lib/validation";
+
+const fields = [
+  { name: "dest", typeName: "AccountId" },
+  { name: "value", typeName: "Balance" },
+];
+
+const values = {
+  dest: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+  value: "1000000000000",
+};
+
+const result = validateAllArgs(client, fields, values);
+
+if (!result.valid) {
+  result.errors.forEach(error => console.error(error));
+}
+```
+
+### validateField()
+
+Validate a single field value against its type.
+
+```typescript
+function validateField(
+  typeName: string,
+  value: unknown,
+  fieldName?: string
+): ValidationResult
+```
+
+**Parameters:**
+- `typeName` - The Substrate type name (e.g., "AccountId", "Balance", "H256")
+- `value` - The value to validate
+- `fieldName` - Optional field name for error messages
+
+**Returns:** `ValidationResult` with validity status and error message
+
+**Example:**
+```typescript
+import { validateField } from "@/lib/validation";
+
+// Validate an account address
+const accountResult = validateField(
+  "AccountId",
+  "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+  "destination"
+);
+
+// Validate a hash
+const hashResult = validateField(
+  "H256",
+  "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+  "blockHash"
+);
+
+// Validate a balance
+const balanceResult = validateField("Balance", "1000", "amount");
+```
+
+**Type-specific validation:**
+
+| Type Pattern | Validation |
+|--------------|------------|
+| `AccountId`, `Address` | SS58 address format |
+| `H256`, `Hash` | 32-byte hex (66 chars with 0x) |
+| `u*`, `i*`, `Balance` | Numeric, non-negative |
+| Other | Required (not empty) |
+
+### validateAmount()
+
+Validate a numeric amount input.
+
+```typescript
+function validateAmount(
+  value: unknown,
+  fieldName?: string
+): ValidationResult
+```
+
+**Parameters:**
+- `value` - The value to validate
+- `fieldName` - Optional field name for error messages (default: "Amount")
+
+**Returns:** `ValidationResult`
+
+**Example:**
+```typescript
+import { validateAmount } from "@/lib/validation";
+
+validateAmount("100");       // { valid: true }
+validateAmount("0");         // { valid: true }
+validateAmount("");          // { valid: false, error: "Amount is required" }
+validateAmount("-5");        // { valid: false, error: "Amount cannot be negative" }
+validateAmount("abc");       // { valid: false, error: "Amount must be a valid number" }
+```
+
+### isValidAddressFormat()
+
+Check if a value has valid SS58 address format.
+
+```typescript
+function isValidAddressFormat(address: unknown): boolean
+```
+
+**Parameters:**
+- `address` - The value to check
+
+**Returns:** `true` if the address has valid SS58 format
+
+**Example:**
+```typescript
+import { isValidAddressFormat } from "@/lib/validation";
+
+isValidAddressFormat("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"); // true
+isValidAddressFormat("HNZata7iMYWmk5RvZRTiAsSDhV8366zq2YGb3tLH5Upf74F");  // true (Kusama)
+isValidAddressFormat("invalid");  // false
+isValidAddressFormat("");         // false
+```
+
+**Validation rules:**
+- Must be a non-empty string
+- Length between 46-50 characters
+- Uses Base58 character set (no 0, O, I, l)
+
+### isValidHexFormat()
+
+Check if a value has valid hex string format.
+
+```typescript
+function isValidHexFormat(value: unknown): boolean
+```
+
+**Parameters:**
+- `value` - The value to check
+
+**Returns:** `true` if the value is a valid hex string
+
+**Example:**
+```typescript
+import { isValidHexFormat } from "@/lib/validation";
+
+isValidHexFormat("0x1234abcd"); // true
+isValidHexFormat("0x");         // true (empty hex)
+isValidHexFormat("0xABCDEF");   // true (uppercase)
+isValidHexFormat("1234abcd");   // false (no 0x prefix)
+isValidHexFormat("0xghij");     // false (invalid characters)
+```
+
+### validateVectorConstraints()
+
+Validate vector/array constraints including min/max items and empty values.
+
+```typescript
+function validateVectorConstraints(
+  items: unknown[],
+  minItems?: number,
+  maxItems?: number,
+  fieldName?: string
+): ValidationResult
+```
+
+**Parameters:**
+- `items` - The array to validate
+- `minItems` - Minimum required items (optional)
+- `maxItems` - Maximum allowed items (optional)
+- `fieldName` - Field name for error messages (default: "Vector")
+
+**Returns:** `ValidationResult`
+
+**Example:**
+```typescript
+import { validateVectorConstraints } from "@/lib/validation";
+
+// Check minimum items
+validateVectorConstraints([1, 2], 3);
+// { valid: false, error: "Vector requires at least 3 items" }
+
+// Check maximum items
+validateVectorConstraints([1, 2, 3, 4], undefined, 3);
+// { valid: false, error: "Vector allows at most 3 items" }
+
+// Check for empty/undefined items
+validateVectorConstraints([1, undefined, 3]);
+// { valid: false, error: "Vector contains 1 empty item" }
+
+// Valid vector
+validateVectorConstraints([1, 2, 3], 2, 5);
+// { valid: true }
+```
+
+### validateStructFields()
+
+Validate that all required struct fields are present and non-empty.
+
+```typescript
+function validateStructFields(
+  values: Record<string, unknown>,
+  requiredFields: string[]
+): ValidationResult
+```
+
+**Parameters:**
+- `values` - Object with field values
+- `requiredFields` - Array of required field names
+
+**Returns:** `ValidationResult`
+
+**Example:**
+```typescript
+import { validateStructFields } from "@/lib/validation";
+
+const values = { name: "Alice", age: 30 };
+
+validateStructFields(values, ["name", "age"]);
+// { valid: true }
+
+validateStructFields(values, ["name", "age", "email"]);
+// { valid: false, error: "Missing required fields: email" }
+
+validateStructFields({ name: "", age: null }, ["name", "age"]);
+// { valid: false, error: "Missing required fields: name, age" }
+```
+
+**Notes:**
+- Considers `undefined`, `null`, and empty string `""` as missing
+- Falsy values like `0` and `false` are considered valid
+
+## Integration with Form Submission
+
+Validation should be performed before encoding and submitting extrinsics:
+
+```typescript
+import { validateAllArgs, encodeAllArgs } from "@/lib";
+
+function handleSubmit(fields, values) {
+  // Step 1: Validate
+  const validation = validateAllArgs(client, fields, values);
+
+  if (!validation.valid) {
+    // Show errors to user
+    validation.results.forEach((result, fieldName) => {
+      if (!result.valid) {
+        setFieldError(fieldName, result.error);
+      }
+    });
+    return;
+  }
+
+  // Step 2: Encode
+  const encoded = encodeAllArgs(client, fields, values);
+
+  if (encoded.hasErrors) {
+    // Handle encoding errors
+    return;
+  }
+
+  // Step 3: Submit
+  submitExtrinsic(encoded.concatenated);
+}
+```

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -1,0 +1,176 @@
+# Component Reference
+
+This documentation covers the input components used in the Relaycode extrinsic builder. Each component handles a specific Substrate type and provides appropriate UI controls for user input.
+
+## Architecture Overview
+
+### Input Component System
+
+All input components live in `components/params/inputs/` and share a common interface:
+
+```
+components/params/
+├── types.ts           # ParamInputProps interface
+└── inputs/
+    ├── account.tsx    # SS58 address input
+    ├── amount.tsx     # Integer numeric input
+    ├── balance.tsx    # Token amount with denominations
+    ├── boolean.tsx    # Boolean toggle
+    ├── bytes.tsx      # Hex byte array
+    ├── call.tsx       # Nested extrinsic builder
+    ├── enum.tsx       # Variant selector
+    ├── hash.tsx       # H256/H160/H512 input
+    ├── option.tsx     # Optional value wrapper
+    ├── struct.tsx     # Composite type container
+    ├── text.tsx       # String/fallback input
+    ├── tuple.tsx      # Positional collection
+    └── vector.tsx     # Dynamic array
+```
+
+### ParamInputProps Interface
+
+All input components implement this common interface:
+
+```typescript
+interface ParamInputProps {
+  name: string;                    // Field identifier
+  label?: string;                  // Display label
+  description?: string;            // Help text
+  isDisabled?: boolean;            // Disable input
+  isRequired?: boolean;            // Show required indicator
+  error?: string;                  // Error message to display
+  client: DedotClient<PolkadotApi>; // Dedot client for type resolution
+  typeId?: number;                 // Type ID for complex type resolution
+  onChange?: (value: unknown) => void;  // Value change callback
+}
+```
+
+### Component Schema Pattern
+
+Each component exports a Zod validation schema:
+
+```typescript
+// Example from amount.tsx
+import { z } from "zod";
+
+const schema = z.string().refine(
+  (val) => !isNaN(Number(val)) && Number(val) >= 0,
+  { message: "Must be a non-negative number" }
+);
+
+export function Amount({ ... }) { ... }
+
+Amount.schema = schema;
+```
+
+## Component Categories
+
+### Primitive Types
+- [AccountInput](./inputs.md#accountinput) - SS58 addresses
+- [AmountInput](./inputs.md#amountinput) - Integers
+- [BalanceInput](./inputs.md#balanceinput) - Token amounts
+- [BoolInput](./inputs.md#boolinput) - Booleans
+- [TextInput](./inputs.md#textinput) - Strings
+
+### Binary Types
+- [BytesInput](./inputs.md#bytesinput) - Byte arrays
+- [HashInput](./inputs.md#hashinput) - Fixed-size hashes
+
+### Composite Types
+- [StructInput](./inputs.md#structinput) - Named field objects
+- [TupleInput](./inputs.md#tupleinput) - Positional arrays
+- [VectorInput](./inputs.md#vectorinput) - Dynamic arrays
+- [OptionInput](./inputs.md#optioninput) - Optional values
+- [EnumInput](./inputs.md#enuminput) - Variant types
+
+### Special Types
+- [CallInput](./inputs.md#callinput) - Nested extrinsics
+
+## Type Resolution
+
+Components are resolved from type names using the [Input Map API](../api/input-map.md):
+
+```typescript
+import { findComponent } from "@/lib/input-map";
+
+// Find component for a Balance type
+const { component: BalanceComponent } = findComponent("Balance");
+
+// Find component with typeId for nested resolution
+const { component: VecComponent } = findComponent("Vec<AccountId>", typeId);
+```
+
+## Value Flow
+
+```
+User Input → Component onChange() → Parent Form State → Encoding
+                                         ↓
+Decoding → Parent Form State → Component value prop → Display
+```
+
+### onChange Callback
+
+Components call `onChange` with the appropriate value type:
+
+| Component | onChange Value Type |
+|-----------|---------------------|
+| Account | `string` (SS58 address) |
+| Amount | `string` (integer as string) |
+| Balance | `string` (planck value as string) |
+| Boolean | `boolean` |
+| Bytes | `string` (hex with 0x) |
+| Hash | `string` (hex with 0x) |
+| Text | `string` |
+| Option | `undefined` or inner value |
+| Vector | `unknown[]` |
+| Struct | `Record<string, unknown>` |
+| Tuple | `unknown[]` |
+| Enum | `{ type: string; value?: unknown }` |
+| Call | `{ type: string; value: { type: string; ...args } }` |
+
+## UI Components
+
+Input components are built on [shadcn/ui](https://ui.shadcn.com/) primitives:
+
+- `Input` - Text fields
+- `Select` - Dropdowns
+- `Switch` - Toggles
+- `Button` - Actions
+- `Card` - Containers
+- `Label` - Field labels
+- `FormDescription` - Help text
+
+## Custom Hooks
+
+Components use several custom hooks:
+
+### useSS58
+Address formatting with chain-specific prefix:
+```typescript
+const { ss58Prefix, formatAddress, isValidAddress, truncateAddress } = useSS58(client);
+```
+
+### useChainToken
+Token symbol and denominations:
+```typescript
+const { symbol, decimals, denominations, existentialDeposit } = useChainToken(client);
+```
+
+### useRecentAddresses
+Recently used address history:
+```typescript
+const { recentAddresses, addRecent } = useRecentAddresses();
+```
+
+### useSafeAccounts / useSafeBalance
+Wallet integration (safe fallbacks when wallet not connected):
+```typescript
+const { accounts } = useSafeAccounts();
+const { transferable, formattedTransferable } = useSafeBalance({ address });
+```
+
+## See Also
+
+- [Input Components Reference](./inputs.md) - Detailed documentation for each component
+- [Input Map API](../api/input-map.md) - Type resolution system
+- [Validation API](../api/validation.md) - Input validation utilities

--- a/docs/components/inputs.md
+++ b/docs/components/inputs.md
@@ -1,0 +1,654 @@
+# Input Components Reference
+
+Detailed documentation for each input component in the Relaycode extrinsic builder.
+
+## AccountInput
+
+**File:** `components/params/inputs/account.tsx`
+
+**Handles:** `AccountId`, `AccountId32`, `AccountId20`, `MultiAddress`, `Address`, `LookupSource`
+
+SS58 address input with wallet integration, address validation, and recent address history.
+
+### Features
+- Combobox with search functionality
+- Connected wallet accounts as options
+- Recent addresses history
+- Address validation using Dedot's `decodeAddress`
+- Automatic SS58 prefix formatting
+- Address truncation for display
+
+### Props
+Standard `ParamInputProps` interface.
+
+### Value Type
+`string` - SS58 formatted address
+
+### Example Usage
+```tsx
+<Account
+  client={client}
+  name="dest"
+  label="Destination"
+  description="The account to receive the transfer"
+  isRequired
+  onChange={(address) => console.log(address)}
+/>
+```
+
+### Screenshot
+```
+┌─────────────────────────────────────────────────────┐
+│ Destination *                                       │
+├─────────────────────────────────────────────────────┤
+│ Select or paste an account...               ▾      │
+├─────────────────────────────────────────────────────┤
+│ ┌─ Connected ─────────────────────────────────────┐ │
+│ │ Alice    5GrwvaEF...utQY                       │ │
+│ │ Bob      5FHneW46...A9Yq                       │ │
+│ └───────────────────────────────────────────────┘ │
+│ ┌─ Recent ────────────────────────────────────────┐ │
+│ │ 5DAAnrj7...8BdV                                │ │
+│ └───────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## AmountInput
+
+**File:** `components/params/inputs/amount.tsx`
+
+**Handles:** `u8`, `u16`, `u32`, `u64`, `u128`, `i8`, `i16`, `i32`, `i64`, `i128`, `Compact<uN>`
+
+Integer numeric input for unsigned and signed integer types.
+
+### Features
+- Numeric input with validation
+- Supports large integers (BigInt for u128)
+- Non-negative validation for unsigned types
+
+### Props
+Standard `ParamInputProps` interface.
+
+### Value Type
+`string` - Integer value as string (for BigInt compatibility)
+
+### Example Usage
+```tsx
+<Amount
+  client={client}
+  name="index"
+  label="Index"
+  description="A u32 index value"
+  onChange={(value) => console.log(value)}
+/>
+```
+
+---
+
+## BalanceInput
+
+**File:** `components/params/inputs/balance.tsx`
+
+**Handles:** `Balance`, `BalanceOf`
+
+Token amount input with denomination selector and wallet balance display.
+
+### Features
+- Denomination selector (DOT, mDOT, planck, etc.)
+- Automatic conversion to planck for encoding
+- Connected wallet balance display
+- "Max" button (balance minus existential deposit)
+- Existential deposit warning
+- Precision validation per denomination
+
+### Props
+Standard `ParamInputProps` interface.
+
+### Value Type
+`string` - Amount in planck (smallest unit) as string
+
+### Example Usage
+```tsx
+<Balance
+  client={client}
+  name="value"
+  label="Amount"
+  description="The amount to transfer"
+  isRequired
+  onChange={(planck) => console.log(planck)}
+/>
+```
+
+### Screenshot
+```
+┌─────────────────────────────────────────────────────┐
+│ Amount *                                            │
+├───────────────────────────────────────────┬────────┤
+│ 1.5                                       │ DOT  ▾ │
+├───────────────────────────────────────────┴────────┤
+│ Available: 10.5 DOT                          [Max] │
+├─────────────────────────────────────────────────────┤
+│ ⚠ Amount would reap account (ED: 1 DOT)            │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## BoolInput
+
+**File:** `components/params/inputs/boolean.tsx`
+
+**Handles:** `bool`
+
+Boolean toggle switch.
+
+### Features
+- Simple on/off toggle using Switch component
+- Clear true/false labeling
+
+### Props
+Standard `ParamInputProps` interface.
+
+### Value Type
+`boolean`
+
+### Example Usage
+```tsx
+<Boolean
+  client={client}
+  name="keepAlive"
+  label="Keep Alive"
+  description="Whether to keep the source account alive"
+  onChange={(value) => console.log(value)}
+/>
+```
+
+---
+
+## BytesInput
+
+**File:** `components/params/inputs/bytes.tsx`
+
+**Handles:** `Bytes`, `Vec<u8>`
+
+Hex byte array input.
+
+### Features
+- Hex string input with 0x prefix
+- Format validation
+- Supports arbitrary length
+
+### Props
+Standard `ParamInputProps` interface.
+
+### Value Type
+`string` - Hex string with 0x prefix
+
+### Example Usage
+```tsx
+<Bytes
+  client={client}
+  name="data"
+  label="Data"
+  description="Arbitrary bytes to include"
+  onChange={(hex) => console.log(hex)}
+/>
+```
+
+---
+
+## CallInput
+
+**File:** `components/params/inputs/call.tsx`
+
+**Handles:** `Call`, `RuntimeCall`, `Box<RuntimeCall>`
+
+Nested extrinsic builder for batch calls and sudo operations.
+
+### Features
+- Pallet selector (from chain metadata)
+- Method selector (filtered by selected pallet)
+- Dynamic parameter inputs based on method signature
+- Full recursive type resolution
+- Builds Dedot-compatible call structure
+
+### Props
+Standard `ParamInputProps` interface.
+
+### Value Type
+```typescript
+{
+  type: string;  // Pallet name (camelCase)
+  value: {
+    type: string;  // Method name (camelCase)
+    [argName: string]: unknown;  // Method arguments
+  }
+}
+```
+
+### Example Usage
+```tsx
+<Call
+  client={client}
+  name="call"
+  label="Inner Call"
+  description="The call to execute via sudo"
+  onChange={(callValue) => console.log(callValue)}
+/>
+```
+
+### Screenshot
+```
+┌─────────────────────────────────────────────────────┐
+│ Inner Call                                          │
+├─────────────────────────────────────────────────────┤
+│ ┌─────────────────────────────────────────────────┐ │
+│ │ Pallet                          [Balances    ▾] │ │
+│ │ Method                    [transferKeepAlive ▾] │ │
+│ │─────────────────────────────────────────────────│ │
+│ │ Parameters                                      │ │
+│ │   dest: [________________________]              │ │
+│ │   value: [____________] [DOT ▾]                 │ │
+│ └─────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## EnumInput
+
+**File:** `components/params/inputs/enum.tsx`
+
+**Handles:** Enum types from metadata
+
+Variant selector with optional inner value input.
+
+### Features
+- Dropdown for variant selection
+- Dynamic inner component based on variant
+- Supports unit variants (no value)
+- Supports variants with associated data
+
+### Props
+Extended interface:
+```typescript
+interface EnumProps extends ParamInputProps {
+  variants: {
+    name: string;
+    component?: React.ReactNode;  // Inner input for this variant
+  }[];
+}
+```
+
+### Value Type
+```typescript
+{
+  type: string;       // Variant name
+  value?: unknown;    // Associated data (if any)
+}
+```
+
+### Example Usage
+```tsx
+<Enum
+  client={client}
+  name="origin"
+  label="Origin"
+  variants={[
+    { name: "Root" },
+    { name: "Signed", component: <Account {...} /> },
+  ]}
+  onChange={(value) => console.log(value)}
+/>
+```
+
+---
+
+## HashInput
+
+**File:** `components/params/inputs/hash.tsx`
+
+**Handles:** `H256`, `H160`, `H512`, `Hash`, `BlockHash`, `ExtrinsicHash`
+
+Fixed-size hash input (32 bytes for H256).
+
+### Features
+- Hex input with 0x prefix
+- Length validation (66 chars for H256)
+- Format validation
+
+### Props
+Standard `ParamInputProps` interface.
+
+### Value Type
+`string` - Hex string with 0x prefix
+
+### Example Usage
+```tsx
+<Hash256
+  client={client}
+  name="hash"
+  label="Block Hash"
+  description="The hash of the target block"
+  onChange={(hash) => console.log(hash)}
+/>
+```
+
+---
+
+## OptionInput
+
+**File:** `components/params/inputs/option.tsx`
+
+**Handles:** `Option<T>`
+
+Optional value wrapper with enable/disable toggle.
+
+### Features
+- Toggle switch to enable/disable the value
+- Wraps any inner component
+- Disabled state dims and disables inner input
+- Returns `undefined` when disabled
+
+### Props
+Extended interface:
+```typescript
+interface OptionProps extends ParamInputProps {
+  children: React.ReactNode;  // The inner input component
+}
+```
+
+### Value Type
+`undefined` (disabled) or inner value type (enabled)
+
+### Example Usage
+```tsx
+<Option
+  client={client}
+  name="maybeRecipient"
+  label="Recipient (Optional)"
+  onChange={(value) => console.log(value)}
+>
+  <Account client={client} name="recipient" />
+</Option>
+```
+
+### Screenshot
+```
+┌─────────────────────────────────────────────────────┐
+│ Recipient (Optional)                     [  ON  ]   │
+├─────────────────────────────────────────────────────┤
+│ [Select account...                              ▾] │
+└─────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────┐
+│ Recipient (Optional)                     [ OFF  ]   │
+├─────────────────────────────────────────────────────┤
+│ [Select account...                              ▾] │  ← Dimmed
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## StructInput
+
+**File:** `components/params/inputs/struct.tsx`
+
+**Handles:** Struct/composite types from metadata
+
+Named field container for composite types.
+
+### Features
+- Card-based grouping of fields
+- Required field validation
+- Dynamic field components via children
+
+### Props
+Extended interface:
+```typescript
+interface StructProps extends ParamInputProps {
+  fields: {
+    name: string;
+    label: string;
+    description?: string;
+    component: React.ReactNode;
+    required?: boolean;
+  }[];
+}
+```
+
+### Value Type
+`Record<string, unknown>` - Object with field values
+
+### Example Usage
+```tsx
+<Struct
+  client={client}
+  name="proposal"
+  label="Proposal"
+  fields={[
+    { name: "title", label: "Title", component: <Text {...} />, required: true },
+    { name: "description", label: "Description", component: <Text {...} /> },
+    { name: "budget", label: "Budget", component: <Balance {...} />, required: true },
+  ]}
+  onChange={(values) => console.log(values)}
+/>
+```
+
+---
+
+## TextInput
+
+**File:** `components/params/inputs/text.tsx`
+
+**Handles:** `String`, `Text`, and fallback for unknown types
+
+Basic string input field.
+
+### Features
+- Simple text input
+- Used as fallback for unrecognized types
+
+### Props
+Standard `ParamInputProps` interface.
+
+### Value Type
+`string`
+
+### Example Usage
+```tsx
+<Text
+  client={client}
+  name="remark"
+  label="Remark"
+  description="A text remark to include"
+  onChange={(text) => console.log(text)}
+/>
+```
+
+---
+
+## TupleInput
+
+**File:** `components/params/inputs/tuple.tsx`
+
+**Handles:** `(T1, T2, ...)`, Tuple types
+
+Positional collection of typed elements.
+
+### Features
+- Resolves element types from registry using typeId
+- Dynamic component resolution for each element
+- Card-based layout with numbered elements
+
+### Props
+Extended interface:
+```typescript
+interface TupleProps extends ParamInputProps {
+  typeId: number;  // Required for type resolution
+}
+```
+
+### Value Type
+`unknown[]` - Array with values at each position
+
+### Example Usage
+```tsx
+<Tuple
+  client={client}
+  name="pair"
+  label="Key-Value Pair"
+  typeId={tupleTypeId}
+  onChange={(values) => console.log(values)}
+/>
+```
+
+### Screenshot
+```
+┌─────────────────────────────────────────────────────┐
+│ Key-Value Pair                                      │
+├─────────────────────────────────────────────────────┤
+│ ┌─────────────────────────────────────────────────┐ │
+│ │ Element 0                                       │ │
+│ │ sp_core::H256                                   │ │
+│ │ [0x________________________________]            │ │
+│ │                                                 │ │
+│ │ Element 1                                       │ │
+│ │ Vec<u8>                                         │ │
+│ │ [0x________________________________]            │ │
+│ └─────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## VectorInput
+
+**File:** `components/params/inputs/vector.tsx`
+
+**Handles:** `Vec<T>`, `BoundedVec<T, S>`
+
+Dynamic array input with add/remove functionality.
+
+### Features
+- Add/remove items dynamically
+- Min/max items constraints
+- Empty item detection and validation
+- Trash icon for item removal
+
+### Props
+Extended interface:
+```typescript
+interface VectorProps extends ParamInputProps {
+  children: React.ReactNode;  // Template component for items
+  minItems?: number;
+  maxItems?: number;
+}
+```
+
+### Value Type
+`unknown[]` - Array of item values
+
+### Example Usage
+```tsx
+<Vector
+  client={client}
+  name="recipients"
+  label="Recipients"
+  minItems={1}
+  maxItems={10}
+  onChange={(values) => console.log(values)}
+>
+  <Account client={client} name="recipient" />
+</Vector>
+```
+
+### Screenshot
+```
+┌─────────────────────────────────────────────────────┐
+│ Recipients (min: 1, max: 10)            [+ Add Item] │
+├─────────────────────────────────────────────────────┤
+│ [5GrwvaEF...utQY                            ▾] [🗑]  │
+│ [5FHneW46...A9Yq                            ▾] [🗑]  │
+│ [Select account...                          ▾] [🗑]  │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## Creating Custom Components
+
+To create a new input component:
+
+```typescript
+// components/params/inputs/my-custom.tsx
+"use client";
+
+import React from "react";
+import { z } from "zod";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { FormDescription } from "@/components/ui/form";
+import type { ParamInputProps } from "../types";
+
+// 1. Define validation schema
+const schema = z.string().min(1, "Value is required");
+
+// 2. Create the component
+export function MyCustom({
+  name,
+  label,
+  description,
+  isDisabled,
+  isRequired,
+  error,
+  client,
+  onChange,
+}: ParamInputProps) {
+  const [value, setValue] = React.useState("");
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    setValue(newValue);
+    onChange?.(newValue);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label htmlFor={name}>
+        {label}
+        {isRequired && <span className="text-red-500 ml-1">*</span>}
+      </Label>
+      <Input
+        id={name}
+        value={value}
+        onChange={handleChange}
+        disabled={isDisabled}
+      />
+      {description && <FormDescription>{description}</FormDescription>}
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}
+
+// 3. Attach schema
+MyCustom.schema = schema;
+```
+
+Then register in `lib/input-map.ts`:
+
+```typescript
+import { MyCustom } from "@/components/params/inputs/my-custom";
+
+const registry = [
+  {
+    component: MyCustom,
+    schema: MyCustom.schema,
+    patterns: ["MyCustomType"],
+    priority: 85,
+  },
+  // ... existing registrations
+];
+```

--- a/docs/medium-article.md
+++ b/docs/medium-article.md
@@ -1,0 +1,147 @@
+# Introducing Relaycode: The Human-Friendly Extrinsics Builder for Polkadot
+
+*Building and submitting Substrate extrinsics shouldn't require a PhD in SCALE encoding. Relaycode makes it accessible to everyone.*
+
+---
+
+## The Problem: Extrinsics Are Hard
+
+If you've ever tried to interact with a Substrate blockchain programmatically, you know the struggle. Want to transfer some tokens? You need to understand pallet indices, method variants, SCALE encoding, compact integers, and the right byte order for your arguments. Even seasoned developers find themselves squinting at hex dumps, trying to figure out why their transaction failed.
+
+Existing tools often present a wall of technical complexity. You're either writing code against low-level APIs, or navigating interfaces that assume you already know exactly what you're doing. For newcomers to the Polkadot ecosystem—or even experienced developers exploring unfamiliar pallets—the learning curve is steep.
+
+This barrier isn't just inconvenient; it's a bottleneck for ecosystem growth. When building and submitting extrinsics requires deep protocol knowledge, we limit who can build on Polkadot.
+
+## Meet Relaycode: Build, Encode, Submit
+
+Relaycode is a modern extrinsic builder designed to transform how developers and users interact with the Polkadot ecosystem. Funded by a Web3 Foundation grant, our mission is simple: make extrinsics accessible.
+
+**What is Relaycode?**
+
+Relaycode is a web application that lets you:
+- **Build any extrinsic** using friendly form inputs
+- **See real-time encoding** as you fill in parameters
+- **Submit transactions** directly from your browser
+- **Decode existing call data** for inspection and modification
+
+Whether you're a developer testing a new pallet, a validator managing nominations, or a user making your first token transfer, Relaycode meets you where you are.
+
+## Key Features
+
+### Dual-Pane Interface with Live Preview
+
+Relaycode's signature feature is its split-view design. On the left, you build your extrinsic using human-readable form inputs. On the right, you see the resulting SCALE-encoded hex in real time.
+
+This isn't just convenient—it's educational. As you change values, you can watch how the encoding changes. Want to understand how addresses are encoded? Change the destination and see which bytes update. Curious about Compact encoding? Watch the hex shrink and grow as you adjust balance values.
+
+### Bi-Directional Editing
+
+Here's where Relaycode really shines: editing works both ways. Fill in a form, get the hex. But you can also paste hex and watch the form populate automatically.
+
+This makes Relaycode invaluable for debugging. Have a failed transaction's call data? Paste it in, see what was actually submitted, fix the error, and resubmit. No more guessing games with hex dumps.
+
+### Full Pallet and Method Coverage
+
+Relaycode reads your chain's metadata directly. Every pallet, every method, every parameter type—it's all available. No hardcoded lists that go stale. Connect to any Substrate chain, and you'll see its complete extrinsic catalog.
+
+The system dynamically resolves complex types. Nested structs, variable-length vectors, optional values, enum variants—Relaycode generates appropriate inputs for each type automatically.
+
+### Smart Type-Aware Inputs
+
+Not all inputs are created equal. An account address needs different handling than a boolean flag or a balance amount. Relaycode provides specialized input components for each type:
+
+- **Account Input**: Dropdown with connected wallet accounts, recent address history, and SS58 validation
+- **Balance Input**: Human-readable amounts (1.5 DOT instead of 15000000000 planck) with denomination switching
+- **Vector Input**: Dynamic add/remove for array parameters
+- **Call Input**: Full nested extrinsic builder for batch operations and sudo calls
+- **Option Input**: Toggle to enable/disable optional parameters
+
+Each input understands its type's constraints and provides appropriate validation.
+
+### Wallet Integration
+
+Relaycode integrates with Polkadot wallet extensions (Polkadot.js, Talisman, SubWallet, and more). Connect your wallet, select an account, and submit transactions without leaving the interface.
+
+Your available balance appears alongside balance inputs, with a "Max" button that calculates the maximum transferable amount (accounting for existential deposit). No more mental math or failed transactions due to insufficient funds.
+
+## Technical Architecture
+
+### Why Dedot, Not polkadot-js?
+
+Relaycode is built on [Dedot](https://github.com/dedotdev/dedot), a modern TypeScript library for Polkadot development. While polkadot-js has served the ecosystem well, Dedot offers significant advantages:
+
+- **Type safety**: Full TypeScript generics for chain-specific types
+- **Smaller bundles**: Modular architecture reduces client-side payload
+- **Modern APIs**: Cleaner interfaces designed for today's development patterns
+- **Active development**: Rapidly evolving with the ecosystem
+
+### SCALE Codec Handling
+
+At its core, Relaycode is a sophisticated SCALE encoder/decoder. The codec layer:
+
+1. Reads type definitions from chain metadata
+2. Coerces form values (strings) to appropriate JavaScript types
+3. Encodes using Dedot's type-safe codec registry
+4. Handles the reverse for decoding
+
+This architecture means Relaycode works with any valid Substrate type—no special handling required for new pallets or custom types.
+
+### Dynamic Component Resolution
+
+The input system uses a priority-based type resolution algorithm:
+
+```
+findComponent("AccountId") → Account input
+findComponent("Vec<Balance>") → Vector of Balance inputs
+findComponent("Option<H256>") → Optional Hash input
+```
+
+When Relaycode encounters a type, it finds the most specific matching component. Generic types recurse, building complex nested input structures automatically.
+
+## Getting Started
+
+Using Relaycode is straightforward:
+
+1. **Visit Relaycode** in your browser
+2. **Connect your wallet** using the button in the header
+3. **Select a pallet** (like Balances) from the dropdown
+4. **Select a method** (like transferKeepAlive)
+5. **Fill in the parameters** using the form inputs
+6. **Review the encoded call** in the right pane
+7. **Click Submit** to sign and send
+
+For your first transaction, try a simple remark (`System.remark`) with some text. It's a free extrinsic that won't transfer any funds—perfect for testing.
+
+## What's Next
+
+Relaycode is actively developed, with exciting features on the roadmap:
+
+**Multi-Chain Support**: Easily switch between Polkadot, Kusama, parachains, and testnets from a single interface.
+
+**Extrinsic Templates**: Save frequently-used extrinsics as templates. Share them with your team or the community.
+
+**Batch Builder**: Visual interface for constructing complex batch transactions with drag-and-drop ordering.
+
+**Historical Analysis**: Decode and analyze historical extrinsics from block explorers.
+
+We're building the tools we wish we had when we started developing on Polkadot. If you have ideas for features that would help your workflow, we'd love to hear them.
+
+## Credits and Acknowledgments
+
+Relaycode is made possible by:
+
+- **Web3 Foundation** for grant funding through the [W3F Grants Program](https://github.com/w3f/Grants-Program)
+- **Dedot** team for their excellent Polkadot client library
+- **The Polkadot community** for feedback and testing
+
+The project is open source. Check out the code, report issues, or contribute at our GitHub repository.
+
+---
+
+*Relaycode: Because building on Polkadot should be about your ideas, not fighting with bytes.*
+
+**Links:**
+- [Try Relaycode](#) (deployment URL)
+- [GitHub Repository](#) (repo URL)
+- [Documentation](./README.md)
+- [W3F Grant Application](#) (grant URL)

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -1,0 +1,462 @@
+# Testing Guide
+
+This guide covers how to run and write tests for Relaycode. The project uses Jest with React Testing Library for unit and integration testing.
+
+## Test Setup
+
+### Configuration Files
+
+**jest.config.ts** - Main Jest configuration:
+```typescript
+import type { Config } from "jest";
+import nextJest from "next/jest";
+
+const createJestConfig = nextJest({
+  dir: "./",
+});
+
+const config: Config = {
+  coverageProvider: "v8",
+  testEnvironment: "jsdom",
+  setupFiles: ["<rootDir>/jest.polyfills.ts"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/$1",
+  },
+};
+```
+
+**ESM Package Handling:**
+Several dependencies ship ESM-only builds. The config transforms these packages:
+- `dedot`, `@dedot/*` - Polkadot client
+- `@noble/hashes`, `@noble/curves` - Cryptography
+- `@scure/base` - Base encoding
+- `@luno-kit/*` - Wallet integration
+
+### Setup Files
+
+**jest.polyfills.ts** - Polyfills for Node.js environment (TextEncoder, crypto, etc.)
+
+**jest.setup.ts** - Test utilities and global mocks
+
+## Running Tests
+
+### Basic Commands
+
+```bash
+# Run all tests
+yarn test
+
+# Run tests in watch mode (re-runs on file changes)
+yarn test:watch
+
+# Run tests with coverage report
+yarn test --coverage
+
+# Run specific test file
+yarn test __tests__/lib/validation.test.ts
+
+# Run tests matching a pattern
+yarn test --testPathPattern="validation"
+```
+
+### Watch Mode Options
+
+In watch mode, press:
+- `a` - Run all tests
+- `f` - Run only failed tests
+- `p` - Filter by filename pattern
+- `t` - Filter by test name pattern
+- `q` - Quit watch mode
+
+## Test Structure
+
+### Directory Layout
+
+```
+__tests__/
+├── hooks/
+│   ├── use-chain-token.test.ts
+│   ├── use-recent-addresses.test.ts
+│   └── use-ss58.test.ts
+├── lib/
+│   ├── denominations.test.ts
+│   ├── parser.test.ts
+│   └── validation.test.ts
+└── input-map.test.ts
+```
+
+### Naming Conventions
+
+- Test files: `*.test.ts` or `*.test.tsx`
+- Test files mirror source structure: `lib/validation.ts` → `__tests__/lib/validation.test.ts`
+- Describe blocks match module/function names
+- Test names describe expected behavior
+
+## Writing Unit Tests
+
+### Testing Utility Functions
+
+Example from `__tests__/lib/validation.test.ts`:
+
+```typescript
+import {
+  validateVectorConstraints,
+  isValidAddressFormat,
+  validateAmount,
+} from "../../lib/validation";
+
+describe("validateVectorConstraints", () => {
+  describe("minItems validation", () => {
+    it("should pass when items >= minItems", () => {
+      const result = validateVectorConstraints([1, 2, 3], 2, undefined);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should fail when items < minItems", () => {
+      const result = validateVectorConstraints([1], 2, undefined, "Items");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("at least 2");
+    });
+  });
+});
+
+describe("isValidAddressFormat", () => {
+  it("should return true for valid Polkadot address", () => {
+    expect(isValidAddressFormat("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")).toBe(true);
+  });
+
+  it("should return false for invalid characters", () => {
+    expect(isValidAddressFormat("0GrwvaEF...")).toBe(false);  // '0' not in Base58
+  });
+});
+```
+
+### Testing Hooks
+
+Example from `__tests__/hooks/use-ss58.test.ts`:
+
+```typescript
+import { renderHook } from "@testing-library/react";
+import { useSS58 } from "../../hooks/use-ss58";
+
+describe("useSS58", () => {
+  describe("when client is null", () => {
+    it("should use default ss58Prefix of 42", () => {
+      const { result } = renderHook(() => useSS58(null));
+      expect(result.current.ss58Prefix).toBe(42);
+    });
+  });
+
+  describe("isValidAddress", () => {
+    it("should return true for valid SS58 addresses", () => {
+      const { result } = renderHook(() => useSS58(null));
+      expect(result.current.isValidAddress("5GrwvaEF...")).toBe(true);
+    });
+  });
+
+  describe("with mock client", () => {
+    it("should use client ss58Prefix when available", () => {
+      const mockClient = {
+        consts: { system: { ss58Prefix: 0 } },
+      } as any;
+
+      const { result } = renderHook(() => useSS58(mockClient));
+      expect(result.current.ss58Prefix).toBe(0);
+    });
+  });
+});
+```
+
+### Testing Type Resolution
+
+Example from `__tests__/input-map.test.ts`:
+
+```typescript
+// Mock components to avoid dependency issues
+jest.mock("../components/params/inputs/account", () => ({
+  Account: { displayName: "Account", schema: {} },
+}));
+
+import { findComponent } from "../lib/input-map";
+import { Account } from "../components/params/inputs/account";
+
+describe("findComponent", () => {
+  describe("Account types (Priority 100)", () => {
+    it("should return Account for AccountId", () => {
+      expect(findComponent("AccountId").component).toBe(Account);
+    });
+
+    it("should match AccountId regex patterns", () => {
+      expect(findComponent("AccountIdOf").component).toBe(Account);
+    });
+  });
+
+  describe("Priority ordering", () => {
+    it("should prefer Bytes over Vector for Vec<u8>", () => {
+      expect(findComponent("Vec<u8>").component).toBe(Bytes);
+    });
+  });
+});
+```
+
+## Mocking Patterns
+
+### Mocking Environment Variables
+
+```typescript
+// Mock env.mjs at the top of test files
+jest.mock("../../env.mjs", () => ({
+  env: {},
+}));
+```
+
+### Mocking Dedot Client
+
+```typescript
+const mockClient = {
+  metadata: {
+    latest: {
+      pallets: [
+        { index: 0, name: "System", calls: 1, docs: [] },
+        { index: 4, name: "Balances", calls: 2, docs: [] },
+      ],
+    },
+  },
+  registry: {
+    findType: jest.fn((typeId) => ({
+      typeDef: { type: "Primitive", value: "u128" },
+    })),
+    findCodec: jest.fn((typeId) => ({
+      tryEncode: jest.fn(),
+      tryDecode: jest.fn(),
+    })),
+  },
+  consts: {
+    system: { ss58Prefix: 0 },
+    balances: { existentialDeposit: BigInt(10000000000) },
+  },
+} as any;
+```
+
+### Mocking Wallet/React Context
+
+```typescript
+// Mock wallet hooks
+jest.mock("../../hooks/use-wallet-safe", () => ({
+  useSafeAccounts: () => ({
+    accounts: [
+      { address: "5GrwvaEF...", name: "Alice" },
+    ],
+  }),
+  useSafeBalance: () => ({
+    transferable: BigInt(100000000000),
+    formattedTransferable: "10",
+  }),
+}));
+```
+
+### Mocking Components with Complex Dependencies
+
+```typescript
+jest.mock("../components/params/inputs/account", () => ({
+  Account: Object.assign(
+    (props: any) => <div data-testid="account-input" />,
+    { schema: {}, displayName: "Account" }
+  ),
+}));
+```
+
+### Mocking localStorage
+
+```typescript
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+```
+
+## Test Examples by Category
+
+### Validation Tests
+
+```typescript
+describe("validateAmount", () => {
+  it("should pass for valid positive numbers", () => {
+    expect(validateAmount("100").valid).toBe(true);
+    expect(validateAmount("1.5").valid).toBe(true);
+  });
+
+  it("should fail for negative values", () => {
+    const result = validateAmount("-5");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("negative");
+  });
+
+  it("should include field name in error", () => {
+    const result = validateAmount("", "Transfer Amount");
+    expect(result.error).toContain("Transfer Amount");
+  });
+});
+```
+
+### Parser Tests
+
+```typescript
+describe("createSectionOptions", () => {
+  it("should filter pallets without calls", () => {
+    const mockMetadata = {
+      pallets: [
+        { index: 0, name: "System", calls: 1, docs: [] },
+        { index: 1, name: "Timestamp", calls: null, docs: [] },
+      ],
+    } as any;
+
+    const result = createSectionOptions(mockMetadata);
+    expect(result).toHaveLength(1);
+    expect(result?.[0].text).toBe("System");
+  });
+
+  it("should sort pallets alphabetically", () => {
+    const mockMetadata = {
+      pallets: [
+        { index: 2, name: "Utility", calls: 1, docs: [] },
+        { index: 0, name: "Balances", calls: 2, docs: [] },
+      ],
+    } as any;
+
+    const result = createSectionOptions(mockMetadata);
+    expect(result?.map(p => p.text)).toEqual(["Balances", "Utility"]);
+  });
+});
+```
+
+### Hook Tests with State Changes
+
+```typescript
+import { renderHook, act } from "@testing-library/react";
+
+describe("useRecentAddresses", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("should add address to recent list", () => {
+    const { result } = renderHook(() => useRecentAddresses());
+
+    act(() => {
+      result.current.addRecent("5GrwvaEF...");
+    });
+
+    expect(result.current.recentAddresses).toContainEqual(
+      expect.objectContaining({ address: "5GrwvaEF..." })
+    );
+  });
+});
+```
+
+## Coverage Requirements
+
+Run coverage report:
+```bash
+yarn test --coverage
+```
+
+### Coverage Thresholds
+
+Target coverage metrics:
+- **Statements:** 80%
+- **Branches:** 75%
+- **Functions:** 80%
+- **Lines:** 80%
+
+### Viewing Coverage
+
+After running with `--coverage`:
+1. Check terminal summary
+2. Open `coverage/lcov-report/index.html` in browser for detailed report
+
+## CI Integration
+
+### GitHub Actions
+
+Example workflow (`.github/workflows/test.yml`):
+
+```yaml
+name: Tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests
+        run: yarn test --coverage --ci
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage/lcov.info
+```
+
+## Debugging Tests
+
+### Verbose Output
+
+```bash
+yarn test --verbose
+```
+
+### Running Single Test
+
+```bash
+yarn test -t "should return Account for AccountId"
+```
+
+### Debug Mode
+
+Add `debugger` statements and run:
+```bash
+node --inspect-brk node_modules/.bin/jest --runInBand
+```
+
+Then open Chrome DevTools at `chrome://inspect`.
+
+## Best Practices
+
+1. **Isolate tests** - Each test should be independent
+2. **Mock external dependencies** - Don't rely on network or real clients
+3. **Test edge cases** - Empty values, invalid inputs, boundary conditions
+4. **Use descriptive names** - Test names should explain expected behavior
+5. **Keep tests focused** - One assertion per test when possible
+6. **Clean up** - Reset mocks and state between tests
+
+## See Also
+
+- [Jest Documentation](https://jestjs.io/docs/getting-started)
+- [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/)
+- [Validation API](./api/validation.md) - Functions being tested

--- a/docs/tutorial/advanced.md
+++ b/docs/tutorial/advanced.md
@@ -1,0 +1,318 @@
+# Advanced Usage
+
+This guide covers advanced features of Relaycode for power users and developers.
+
+## Bi-Directional Editing
+
+Relaycode supports seamless switching between form-based and hex-based editing. Changes in either pane are instantly reflected in the other.
+
+### Form → Hex Flow
+
+1. Fill in the form fields
+2. Watch the hex pane update in real-time
+3. Each field change re-encodes the entire call
+
+```
+Form Input:                         Hex Output:
+┌───────────────────────────┐       ┌───────────────────────────┐
+│ dest: 5GrwvaEF...utQY     │  ───► │ 0x0503d43593c715...      │
+│ value: 1 DOT              │       │                          │
+└───────────────────────────┘       └───────────────────────────┘
+```
+
+### Hex → Form Flow
+
+1. Paste or edit hex in the right pane
+2. The system decodes and populates the form
+3. Invalid hex shows an error message
+
+```
+Hex Input:                          Form Output:
+┌───────────────────────────┐       ┌───────────────────────────┐
+│ 0x0503d43593c715...       │  ───► │ dest: 5GrwvaEF...utQY     │
+│                           │       │ value: 1000000000000      │
+└───────────────────────────┘       └───────────────────────────┘
+```
+
+### Decoding Existing Call Data
+
+To decode an existing extrinsic:
+
+1. Select the correct pallet and method first
+2. Paste the arguments hex (not the full extrinsic)
+3. The form populates with decoded values
+
+**Note:** The hex should be just the encoded arguments, not including the pallet/method prefix.
+
+## Batch Transactions
+
+Use `Utility.batch` or `Utility.batchAll` to execute multiple calls in a single transaction.
+
+### Creating a Batch
+
+1. Select **Utility** pallet
+2. Select **batch** or **batchAll** method
+3. Add calls using the nested Call input
+
+### batch vs batchAll
+
+| Method | Behavior on Failure |
+|--------|---------------------|
+| `batch` | Continues executing remaining calls |
+| `batchAll` | Rolls back all calls (atomic) |
+
+### Example: Multiple Transfers
+
+```
+Utility.batchAll
+└── calls
+    ├── [0] Balances.transferKeepAlive
+    │       dest: 5FHneW46...
+    │       value: 1 DOT
+    │
+    └── [1] Balances.transferKeepAlive
+            dest: 5DAAnrj7...
+            value: 2 DOT
+```
+
+### Nested Batch Calls
+
+Batches can contain any calls, including other batches:
+
+```
+Utility.batch
+└── calls
+    ├── [0] Balances.transferKeepAlive
+    │
+    └── [1] Utility.batch  ← Nested batch
+            └── calls
+                ├── [0] System.remark
+                └── [1] System.remark
+```
+
+## Complex Types
+
+### Structs
+
+Structs group multiple named fields together. Relaycode renders each field with its appropriate input component.
+
+```
+ProposalInfo {
+  title: String     → Text input
+  description: String → Text input
+  budget: Balance   → Balance input
+  recipient: AccountId → Account input
+}
+```
+
+### Tuples
+
+Tuples are ordered collections of typed values. They appear as numbered elements:
+
+```
+(AccountId, Balance, bool)
+
+Element 0: [Account input]
+Element 1: [Balance input]
+Element 2: [Boolean toggle]
+```
+
+### Enums
+
+Enums represent a choice between variants. Some variants have associated data:
+
+```
+Origin {
+  Root         → No additional input
+  Signed(AccountId) → Shows Account input when selected
+  None         → No additional input
+}
+```
+
+**Usage:**
+1. Select the variant from the dropdown
+2. If the variant has data, fill in the inner input
+
+### Nested Calls
+
+The `Call` input allows building any extrinsic as a parameter:
+
+```
+Sudo.sudo
+└── call: Call
+    └── [Nested pallet/method selector]
+        └── [Parameters for nested call]
+```
+
+Common uses:
+- `Sudo.sudo` - Execute privileged calls
+- `Utility.batch` - Batch multiple calls
+- `Multisig.asMulti` - Multi-signature calls
+- `Proxy.proxy` - Proxy calls
+
+## Working with Vectors
+
+Vector inputs allow dynamic arrays of any type.
+
+### Adding Items
+
+Click **"+ Add Item"** to add a new element. A new input row appears.
+
+### Removing Items
+
+Click the **trash icon** next to an item to remove it.
+
+### Constraints
+
+Some vectors have min/max constraints:
+
+```
+Recipients (min: 1, max: 10)  ← Shows constraint info
+```
+
+- Cannot remove items below minimum
+- Cannot add items above maximum
+
+### Nested Vectors
+
+Vectors can contain any type, including other vectors:
+
+```
+Vec<Vec<AccountId>>
+
+[0] ─┬─ [0] 5GrwvaEF...
+     └─ [1] 5FHneW46...
+
+[1] ─┬─ [0] 5DAAnrj7...
+     └─ [1] 5GNJqTPy...
+```
+
+## Option Types
+
+Optional values can be present or absent.
+
+### Enabling/Disabling
+
+Toggle the switch to enable or disable the value:
+
+- **Enabled:** Shows the inner input, value is included
+- **Disabled:** Inner input is dimmed, value is `null`/`None`
+
+### In Encoded Output
+
+```
+Enabled:  Some(value) → 0x01[encoded_value]
+Disabled: None        → 0x00
+```
+
+## Denominations and Balance Precision
+
+### Available Denominations
+
+For Polkadot:
+| Denomination | Multiplier | Example |
+|--------------|------------|---------|
+| DOT | 10^10 planck | 1 DOT = 10,000,000,000 planck |
+| mDOT | 10^7 planck | 1 mDOT = 10,000,000 planck |
+| planck | 1 | Base unit |
+
+### Precision Handling
+
+- Each denomination has a maximum decimal precision
+- DOT allows up to 10 decimal places
+- Planck allows only whole numbers (integers)
+
+```
+Valid:   1.5 DOT     → 15000000000 planck
+Valid:   0.0000000001 DOT → 1 planck
+Invalid: 0.00000000001 DOT → Error (excess precision)
+```
+
+### Conversion
+
+Switching denominations converts the displayed value:
+
+```
+1.5 DOT → 1500 mDOT → 15000000000 planck
+```
+
+The underlying planck value remains the same.
+
+## Error Handling
+
+### Encoding Errors
+
+When a value can't be encoded:
+- The hex pane shows the last valid encoding
+- An error message appears below the field
+- Submit is disabled until fixed
+
+Common causes:
+- Invalid address format
+- Wrong type (e.g., text in number field)
+- Missing required fields
+
+### Decoding Errors
+
+When hex can't be decoded:
+- Form fields show last valid values
+- Error message in hex pane
+- Invalid hex is highlighted
+
+Common causes:
+- Incomplete hex (truncated data)
+- Wrong pallet/method selected
+- Malformed hex (non-hex characters)
+
+### Validation Errors
+
+Pre-submission validation catches:
+- Missing required fields
+- Invalid formats (addresses, hashes)
+- Constraint violations (vector length)
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Tab` | Move to next field |
+| `Shift+Tab` | Move to previous field |
+| `Enter` | Submit (when focused on submit button) |
+| `Escape` | Close dropdowns/modals |
+
+## Tips for Developers
+
+### Inspecting Encoded Calls
+
+Use the hex output to understand SCALE encoding:
+
+```
+0x0503d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0700e8764817
+
+05   - Pallet index (Balances = 5)
+03   - Method index (transferKeepAlive = 3)
+00   - MultiAddress variant (Id = 0)
+d4.. - AccountId (32 bytes)
+07.. - Compact<Balance> encoded value
+```
+
+### Testing Encoding
+
+1. Build a call via form
+2. Copy the hex
+3. Decode in polkadot.js apps to verify
+4. Or use Dedot's codec directly
+
+### Debugging Decode Issues
+
+If decode fails:
+1. Check hex starts with `0x`
+2. Verify pallet/method match the hex
+3. Check byte length matches expected
+4. Try decoding individual arguments
+
+## See Also
+
+- [API Reference](../api/README.md) - Programmatic usage
+- [Component Reference](../components/README.md) - Input component details
+- [Testing Guide](../testing-guide.md) - Testing extrinsic building

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -1,0 +1,199 @@
+# Getting Started with Relaycode
+
+Welcome to Relaycode! This tutorial will guide you through building and submitting your first extrinsic on Polkadot.
+
+## What is Relaycode?
+
+Relaycode is an extrinsic builder for the Polkadot ecosystem. It provides a user-friendly interface for:
+
+- **Building extrinsics** - Construct any pallet call using human-readable forms
+- **Encoding/Decoding** - Convert between form values and SCALE-encoded hex
+- **Wallet integration** - Connect your wallet to sign and submit transactions
+- **Bi-directional editing** - Edit via form or raw hex, with real-time sync
+
+## Prerequisites
+
+- A Polkadot-compatible wallet (Polkadot.js extension, Talisman, SubWallet, etc.)
+- Some DOT or testnet tokens for transaction fees
+
+## Connecting Your Wallet
+
+1. **Open Relaycode** and navigate to the Builder page
+2. **Click "Connect Wallet"** in the top navigation
+3. **Select your wallet** from the available options
+4. **Approve the connection** in your wallet extension
+5. Your connected accounts will appear in the Account selector
+
+Once connected, you'll see your account balance and be able to select accounts for transactions.
+
+## Understanding the Interface
+
+Relaycode uses a dual-pane interface:
+
+```
+┌─────────────────────────────────┬─────────────────────────────────┐
+│                                 │                                 │
+│         FORM PANE               │         HEX PANE                │
+│                                 │                                 │
+│  Human-readable inputs          │  SCALE-encoded call data        │
+│  - Pallet selector              │  - Live hex preview             │
+│  - Method selector              │  - Editable hex input           │
+│  - Parameter inputs             │  - Auto-decode on edit          │
+│                                 │                                 │
+└─────────────────────────────────┴─────────────────────────────────┘
+```
+
+**Left Pane (Form):** Select pallets, methods, and fill in parameters using friendly input components.
+
+**Right Pane (Hex):** See the resulting encoded call data in real-time. You can also paste hex to decode and edit.
+
+## Building Your First Extrinsic
+
+Let's create a simple balance transfer:
+
+### Step 1: Select Pallet and Method
+
+1. In the **Pallet** dropdown, search for and select **"Balances"**
+2. In the **Method** dropdown, select **"transferKeepAlive"**
+
+The form will update to show the required parameters.
+
+### Step 2: Fill in Parameters
+
+The transfer requires two parameters:
+
+**dest (Destination)**
+- Click the destination field
+- Select an account from your connected accounts, or
+- Paste an SS58 address, or
+- Select from recent addresses
+
+**value (Amount)**
+- Enter the amount to transfer
+- Use the denomination selector (DOT, mDOT, planck)
+- Your available balance is shown below the input
+- Click "Max" to fill your maximum transferable amount
+
+### Step 3: Review the Encoded Call
+
+As you fill in the form, the right pane updates with the encoded call data:
+
+```
+0x0503d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0700e8764817
+```
+
+This hex represents your complete extrinsic call:
+- `05` - Balances pallet index
+- `03` - transferKeepAlive method index
+- Remaining bytes - Encoded destination and amount
+
+### Step 4: Submit the Transaction
+
+1. Review your transaction details
+2. Click **"Submit"**
+3. Your wallet will prompt you to sign
+4. Approve the transaction in your wallet
+5. Wait for confirmation
+
+You'll see a success message with the transaction hash once it's included in a block.
+
+## Input Types Explained
+
+Relaycode provides specialized inputs for different Substrate types:
+
+### Account Input
+For addresses and account IDs:
+- Dropdown with connected accounts
+- Recent address history
+- Paste any valid SS58 address
+- Automatic format validation
+
+### Balance Input
+For token amounts:
+- Human-readable input (e.g., "1.5")
+- Denomination selector (DOT/mDOT/planck)
+- Automatic conversion to planck
+- Available balance display
+- Existential deposit warning
+
+### Amount Input
+For plain integers (u32, u64, u128):
+- Simple numeric input
+- Supports large numbers (BigInt)
+
+### Boolean Input
+For true/false values:
+- Toggle switch
+
+### Hash Input
+For block hashes, extrinsic hashes (H256):
+- 32-byte hex input
+- Format validation
+
+### Vector Input
+For arrays (Vec<T>):
+- Add/remove items
+- Dynamic length
+
+### Option Input
+For optional values (Option<T>):
+- Toggle to enable/disable
+- Inner input when enabled
+
+## Common Extrinsics
+
+Here are some common extrinsics you can build:
+
+### Balance Transfer
+**Pallet:** Balances
+**Method:** transferKeepAlive
+**Parameters:**
+- dest: Destination address
+- value: Amount in planck
+
+### Remark
+**Pallet:** System
+**Method:** remark
+**Parameters:**
+- remark: Bytes data (hex)
+
+### Set Identity
+**Pallet:** Identity
+**Method:** setIdentity
+**Parameters:**
+- info: Identity info struct
+
+### Batch Calls
+**Pallet:** Utility
+**Method:** batch
+**Parameters:**
+- calls: Array of nested calls
+
+## Troubleshooting
+
+### "Invalid address" error
+- Ensure the address uses valid Base58 characters
+- Check the address length (typically 47-48 characters)
+- Verify it's a valid SS58 address for the target chain
+
+### "Insufficient balance" error
+- Account needs funds for transfer + fees
+- Remember the existential deposit (1 DOT on Polkadot)
+
+### Transaction not submitting
+- Check wallet is connected
+- Ensure you have enough balance for fees
+- Check network connectivity
+
+### Form not updating from hex
+- Ensure hex is valid (starts with 0x)
+- Hex must match the selected pallet/method
+- Check for encoding errors in the hex
+
+## Next Steps
+
+Now that you've completed your first transaction, explore:
+
+- [Advanced Usage](./advanced.md) - Bi-directional editing, batch calls, complex types
+- [API Reference](../api/README.md) - Use Relaycode programmatically
+- [Component Reference](../components/README.md) - Understand input components


### PR DESCRIPTION
## Summary

Complete the remaining M2 documentation deliverables from the W3F grant:

### Deliverable 0b: Comprehensive Documentation
- **API Reference** (`docs/api/`)
  - Codec API (encoding/decoding functions)
  - Validation API (input validation utilities)
  - Parser API (metadata parsing)
  - Input Map API (type resolution system)
- **Component Reference** (`docs/components/`)
  - Architecture overview
  - Detailed docs for all 14 input components
- **Tutorials** (`docs/tutorial/`)
  - Getting started guide
  - Advanced usage (bi-directional editing, batch calls, complex types)

### Deliverable 0c: Testing Guide
- `docs/testing-guide.md` covering:
  - Jest configuration and ESM handling
  - Running tests and coverage
  - Writing unit tests with examples
  - Mocking patterns (DedotClient, wallet, localStorage)
  - CI/GitHub Actions integration

### Deliverable 0e: Medium Article Draft
- `docs/medium-article.md` (~1500 words) covering:
  - Problem statement and Relaycode solution
  - Key features overview
  - Technical architecture
  - Getting started guide
  - Roadmap and acknowledgments

### README Updates
- Added Documentation section with links
- Updated component checklist (16 implemented, 4 planned)

## Test plan
- [ ] Verify all documentation links work
- [ ] Review API docs accuracy against source code
- [ ] Check code examples are correct
- [ ] Verify component docs match implementation