### PR TITLE
Add site placeholder pages and layout polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Relaycode is an intuitive extrinsics builder designed to transform the way devel
 - Styling: Tailwind CSS, shadcn/ui components
 - State Management: React Hooks, Context API
 - Polkadot Integration: [Dedot](https://github.com/dedotdev/dedot)
+- Wallet: [LunoKit](https://github.com/nickytonline/luno-kit) (Polkadot.js, Talisman, SubWallet)
+- Chains: Polkadot, Kusama, Westend (testnet)
 - Theming: next-themes for dark/light mode support
 
 ## Documentation
@@ -46,12 +48,16 @@ The following input components have been implemented for the extrinsic builder:
 
 - [x] **Account** - Handles `AccountId`, `Address`, `LookupSource`, `MultiAddress`
 - [x] **Amount** - Handles `i8`, `i16`, `i32`, `i64`, `i128`, `u8`, `u16`, `u32`, `u64`, `u128`, `Compact<uN>`
-- [x] **Balance** - Handles `Balance`, `BalanceOf`
+- [x] **Balance** - Handles `Balance`, `BalanceOf`, `Compact<Balance>`, `Compact<BalanceOf>`
 - [x] **Bool** - Handles `bool`
+- [x] **BTreeMap** - Handles `BTreeMap<K, V>` with typed key-value pair inputs
+- [x] **BTreeSet** - Handles `BTreeSet<T>` with duplicate detection
 - [x] **Bytes** - Handles `Bytes`, `Vec<u8>`
 - [x] **Call** - Handles `Call`, `RuntimeCall`
 - [x] **Enum** - Handles enum types from metadata
-- [x] **Hash256** - Handles `Hash`, `H256`
+- [x] **Hash160** - Handles `H160` (20-byte hash)
+- [x] **Hash256** - Handles `Hash`, `H256` (32-byte hash)
+- [x] **Hash512** - Handles `H512` (64-byte hash)
 - [x] **KeyValue** - Handles `KeyValue`
 - [x] **Moment** - Handles `Moment`, `MomentOf`
 - [x] **Option** - Handles `Option<T>`
@@ -59,12 +65,15 @@ The following input components have been implemented for the extrinsic builder:
 - [x] **Struct** - Handles composite/struct types
 - [x] **Tuple** - Handles tuple types `(T1, T2, ...)`
 - [x] **Vector** - Handles `Vec<T>`, `BoundedVec<T, S>`
+- [x] **VectorFixed** - Handles fixed-length arrays `[T; N]`
 - [x] **Vote** - Handles `Vote`
 - [x] **VoteThreshold** - Handles `VoteThreshold`
 
-### Planned Components
+### M2 Features
 
-- [ ] **Hash160** - Handles `H160`
-- [ ] **Hash512** - Handles `H512`
-- [ ] **BTreeMap** - Handles `BTreeMap`
-- [ ] **VectorFixed** - Handles fixed-length arrays
+- [x] **Chain Selector** - Switch between Polkadot, Kusama, and Westend (testnet) from the navbar
+- [x] **Type Badges** - Builder displays Substrate type names alongside field labels
+- [x] **Wallet Integration** - LunoKit-based wallet connect (Polkadot.js, Talisman, SubWallet)
+- [x] **Bi-Directional Editing** - Edit via form or raw hex, with real-time sync
+- [x] **Transaction Submission** - Sign and submit extrinsics directly from the builder
+- [x] **Input Validation** - Pre-submission validation with descriptive error messages

--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -1,0 +1,10 @@
+import { ComingSoon } from "@/components/shared/coming-soon";
+
+export default function ApiDocsPage() {
+  return (
+    <ComingSoon
+      title="API Reference"
+      description="Full API reference for Relaycode integration. Coming soon."
+    />
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,10 @@
+import { ComingSoon } from "@/components/shared/coming-soon";
+
+export default function BlogPage() {
+  return (
+    <ComingSoon
+      title="Blog"
+      description="Updates, tutorials, and insights from the Relaycode team. Coming soon."
+    />
+  );
+}

--- a/app/components/page.tsx
+++ b/app/components/page.tsx
@@ -1,0 +1,10 @@
+import { ComingSoon } from "@/components/shared/coming-soon";
+
+export default function ComponentsPage() {
+  return (
+    <ComingSoon
+      title="UI Components"
+      description="Reusable Substrate-aware UI components for your dApp. Coming soon."
+    />
+  );
+}

--- a/app/discord/page.tsx
+++ b/app/discord/page.tsx
@@ -1,0 +1,10 @@
+import { ComingSoon } from "@/components/shared/coming-soon";
+
+export default function DiscordPage() {
+  return (
+    <ComingSoon
+      title="Discord Community"
+      description="Our Discord server is being set up. Check back soon to join the community."
+    />
+  );
+}

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,0 +1,10 @@
+import { ComingSoon } from "@/components/shared/coming-soon";
+
+export default function DocsPage() {
+  return (
+    <ComingSoon
+      title="Documentation"
+      description="Comprehensive guides for using Relaycode. Coming soon."
+    />
+  );
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,10 @@
+import { ComingSoon } from "@/components/shared/coming-soon";
+
+export default function PrivacyPage() {
+  return (
+    <ComingSoon
+      title="Privacy Policy"
+      description="Our privacy policy is being finalized. Coming soon."
+    />
+  );
+}

--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -1,0 +1,10 @@
+import { ComingSoon } from "@/components/shared/coming-soon";
+
+export default function SecurityPage() {
+  return (
+    <ComingSoon
+      title="Security Audit"
+      description="Security audit reports and vulnerability disclosures. Coming soon."
+    />
+  );
+}

--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -1,0 +1,10 @@
+import { ComingSoon } from "@/components/shared/coming-soon";
+
+export default function TemplatesPage() {
+  return (
+    <ComingSoon
+      title="Form Templates"
+      description="Pre-built extrinsic templates for common operations. Coming soon."
+    />
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,10 @@
+import { ComingSoon } from "@/components/shared/coming-soon";
+
+export default function TermsPage() {
+  return (
+    <ComingSoon
+      title="Terms of Service"
+      description="Our terms of service are being finalized. Coming soon."
+    />
+  );
+}

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -1,0 +1,10 @@
+import { ComingSoon } from "@/components/shared/coming-soon";
+
+export default function ToolsPage() {
+  return (
+    <ComingSoon
+      title="Substrate Tools"
+      description="Developer tools for Substrate chain interaction. Coming soon."
+    />
+  );
+}

--- a/app/tutorials/page.tsx
+++ b/app/tutorials/page.tsx
@@ -1,0 +1,10 @@
+import { ComingSoon } from "@/components/shared/coming-soon";
+
+export default function TutorialsPage() {
+  return (
+    <ComingSoon
+      title="Video Tutorials"
+      description="Step-by-step video guides for Polkadot development. Coming soon."
+    />
+  );
+}

--- a/components/layout/site-footer.tsx
+++ b/components/layout/site-footer.tsx
@@ -13,7 +13,7 @@ const footerLinks = {
   learn: [
     { name: "Documentation", href: "/docs" },
     { name: "Video Tutorials", href: "/tutorials" },
-    { name: "API Reference", href: "/api" },
+    { name: "API Reference", href: "/api-docs" },
     { name: "Security Audit", href: "/security" },
   ],
   community: [

--- a/components/layout/site-header.tsx
+++ b/components/layout/site-header.tsx
@@ -7,6 +7,7 @@ import { ModeToggle } from "@/components/layout/mode-toggle";
 import useScroll from "@/hooks/use-scroll";
 
 import { ConnectButton } from "@/components/shared/connect-button";
+import { ChainSelector } from "@/components/shared/chain-selector";
 
 interface NavBarProps {
   items?: MainNavItem[];
@@ -33,6 +34,7 @@ export function NavBar({
 
         <div className="flex items-center space-x-3">
           {rightElements}
+          <ChainSelector />
           <ConnectButton />
           <div className="ml-8">
             <ModeToggle />

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -3,6 +3,7 @@
 import { motion } from "framer-motion";
 import Balancer from "react-wrap-balancer";
 
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { AuroraBackground } from "@/components/layout/aurora-background";
 import { ArrowRight, PlayCircle } from "lucide-react";
@@ -37,13 +38,15 @@ export function HeroSection() {
               </Balancer>
             </p>
             <div className="mt-10">
-              <Button
-                size="lg"
-                className="text-lg rounded-full group px-8 py-3 h-auto"
-              >
-                Try Extrinsic Builder (Beta)
-                <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" />
-              </Button>
+              <Link href="/builder">
+                <Button
+                  size="lg"
+                  className="text-lg rounded-full group px-8 py-3 h-auto"
+                >
+                  Try Extrinsic Builder (Beta)
+                  <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" />
+                </Button>
+              </Link>
             </div>
 
             {/* Demo Section */}

--- a/components/shared/coming-soon.tsx
+++ b/components/shared/coming-soon.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+
+interface ComingSoonProps {
+  title: string;
+  description?: string;
+}
+
+export function ComingSoon({ title, description }: ComingSoonProps) {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-6 text-center">
+      <h1 className="text-4xl font-bold font-heading tracking-tight">
+        {title}
+      </h1>
+      <p className="mt-4 text-lg text-muted-foreground max-w-md">
+        {description || "This page is coming soon. Stay tuned for updates."}
+      </p>
+      <Link href="/builder" className="mt-8">
+        <Button variant="outline" className="gap-2">
+          <ArrowLeft className="h-4 w-4" />
+          Back to Builder
+        </Button>
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add coming-soon placeholder pages for 11 site routes (api-docs, blog, components, discord, docs, privacy, security, templates, terms, tools, tutorials)
- Add shared `ComingSoon` component for consistent placeholder UX
- Update site header navigation links and footer
- Polish hero section copy and styling
- Update README project description

## Test plan
- [ ] Verify all placeholder pages render at their routes
- [ ] Verify header navigation links work
- [ ] Verify footer links are correct
- [ ] Visual check on hero section