### PR TITLE
Enhance M2 input components with new types and polish

### DIFF
--- a/components/builder/extrinsic-builder.tsx
+++ b/components/builder/extrinsic-builder.tsx
@@ -11,6 +11,7 @@ import {
   Form,
   FormField,
   FormItem,
+  FormLabel,
   FormDescription,
 } from "@/components/ui/form";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -248,16 +249,24 @@ const ExtrinsicBuilder: React.FC<ExtrinsicBuilderProps> = ({
                 control={builderForm.control}
                 name={arg.name || ""}
                 render={({ field }) => {
-                  const resolved = findComponent(arg.typeName || "", arg.typeId);
+                  const resolved = findComponent(arg.typeName || "", arg.typeId, client);
                   const Component = resolved.component;
                   return (
                     <FormItem className="ml-8">
-                      <Component
-                        client={client}
-                        label={arg.name || ""}
-                        typeId={resolved.typeId}
-                        {...field}
-                      />
+                      <div className="relative">
+                        {arg.typeName && (
+                          <span className="absolute right-0 top-0 text-xs text-muted-foreground font-mono bg-muted px-2 py-0.5 rounded z-10">
+                            {arg.typeName}
+                          </span>
+                        )}
+                        <Component
+                          client={client}
+                          label={arg.name || ""}
+                          typeName={arg.typeName || ""}
+                          typeId={resolved.typeId}
+                          {...field}
+                        />
+                      </div>
                     </FormItem>
                   );
                 }}

--- a/components/params/inputs/account.tsx
+++ b/components/params/inputs/account.tsx
@@ -35,6 +35,7 @@ export function Account({
   error,
   client,
   onChange,
+  value: externalValue,
 }: ParamInputProps) {
   const { accounts } = useSafeAccounts();
   const { recentAddresses, addRecent } = useRecentAddresses();
@@ -54,8 +55,18 @@ export function Account({
     return recentAddresses.map((r) => r.address);
   }, [recentAddresses]);
 
-  // Track current value
+  // Track current value (internal state for the combobox)
   const [value, setValue] = React.useState<string | undefined>(undefined);
+
+  // Sync from external value (e.g., hex decode setting form value)
+  React.useEffect(() => {
+    if (externalValue !== undefined && externalValue !== null && externalValue !== "") {
+      const extStr = String(externalValue);
+      if (extStr !== value) {
+        setValue(extStr);
+      }
+    }
+  }, [externalValue]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleChange = useCallback(
     (address: string | undefined) => {

--- a/components/params/inputs/amount.tsx
+++ b/components/params/inputs/amount.tsx
@@ -39,6 +39,7 @@ export function Amount({
   client,
   typeName,
   onChange,
+  value: externalValue,
 }: AmountProps) {
   const isDenominated =
     typeName !== undefined && BALANCE_LIKE_TYPES.has(typeName);
@@ -66,6 +67,27 @@ export function Amount({
       setSelectedDenomLabel(denominations[0].label);
     }
   }, [isDenominated, denominations, selectedDenomLabel]);
+
+  // Sync from external value (e.g., hex decode setting form value)
+  React.useEffect(() => {
+    if (externalValue !== undefined && externalValue !== null && externalValue !== "") {
+      if (isDenominated && selectedDenom) {
+        const planckStr = String(externalValue);
+        const currentPlanck = displayValue.trim()
+          ? toPlanck(displayValue, selectedDenom)
+          : null;
+        if (currentPlanck !== planckStr) {
+          setDisplayValue(fromPlanck(planckStr, selectedDenom));
+        }
+      } else {
+        // Plain numeric mode
+        const numStr = String(externalValue);
+        if (displayValue !== numStr) {
+          setDisplayValue(numStr);
+        }
+      }
+    }
+  }, [externalValue, selectedDenom, isDenominated]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Denominated change handler
   const handleDenominatedChange = useCallback(
@@ -178,8 +200,10 @@ export function Amount({
         id={name}
         type="number"
         disabled={isDisabled}
+        value={displayValue}
         onChange={handlePlainChange}
         className="font-mono"
+        placeholder="0"
         min={0}
       />
       {description && <FormDescription>{description}</FormDescription>}

--- a/components/params/inputs/balance.tsx
+++ b/components/params/inputs/balance.tsx
@@ -40,6 +40,7 @@ export function Balance({
   error,
   client,
   onChange,
+  value: externalValue,
 }: ParamInputProps) {
   const { symbol, denominations, existentialDeposit, loading } =
     useChainToken(client);
@@ -63,6 +64,21 @@ export function Balance({
       setSelectedDenomLabel(denominations[0].label);
     }
   }, [denominations, selectedDenomLabel]);
+
+  // Sync from external planck value (e.g., hex decode setting form value)
+  React.useEffect(() => {
+    if (externalValue !== undefined && externalValue !== null && externalValue !== "") {
+      const planckStr = String(externalValue);
+      // Check if current display already represents this planck value
+      const currentPlanck = displayValue.trim() && selectedDenom
+        ? toPlanck(displayValue, selectedDenom)
+        : null;
+      if (currentPlanck !== planckStr && selectedDenom) {
+        const display = fromPlanck(planckStr, selectedDenom);
+        setDisplayValue(display);
+      }
+    }
+  }, [externalValue, selectedDenom]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Wallet info (safe hooks that handle missing provider)
   const { address } = useSafeAccount();

--- a/components/params/inputs/boolean.tsx
+++ b/components/params/inputs/boolean.tsx
@@ -15,6 +15,7 @@ export function Boolean({
   isRequired,
   error,
   onChange,
+  value: externalValue,
 }: ParamInputProps) {
   return (
     <div className="flex flex-col gap-2">
@@ -29,6 +30,7 @@ export function Boolean({
         <Switch
           id={name}
           disabled={isDisabled}
+          checked={externalValue === true || externalValue === "true"}
           onCheckedChange={onChange}
           aria-label={label}
         />

--- a/components/params/inputs/btree-map.tsx
+++ b/components/params/inputs/btree-map.tsx
@@ -1,0 +1,177 @@
+import React from "react";
+import { z } from "zod";
+import { Label } from "@/components/ui/label";
+import { FormDescription } from "@/components/ui/form";
+import { Button } from "@/components/ui/button";
+import { Plus, Trash2 } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import type { ParamInputProps } from "../types";
+import { findComponent } from "@/lib/input-map";
+
+interface BTreeMapProps extends ParamInputProps {
+  typeId: number;
+}
+
+const schema = z.array(z.tuple([z.any(), z.any()]));
+
+export function BTreeMap({
+  name,
+  label,
+  description,
+  isDisabled,
+  isRequired,
+  error,
+  onChange,
+  client,
+  typeId,
+}: BTreeMapProps) {
+  const [pairs, setPairs] = React.useState<[unknown, unknown][]>([[undefined, undefined]]);
+
+  // Resolve key/value types from registry
+  const { keyType, valueType } = React.useMemo(() => {
+    if (!client || typeId === undefined) return { keyType: null, valueType: null };
+    try {
+      const typeInfo = client.registry.findType(typeId);
+      // BTreeMap is a Sequence of Tuples in SCALE metadata
+      if (typeInfo.typeDef.type === "Sequence") {
+        const entryTypeId = typeInfo.typeDef.value.typeParam;
+        const entryType = client.registry.findType(entryTypeId);
+        if (entryType.typeDef.type === "Tuple" && entryType.typeDef.value.fields.length === 2) {
+          const keyTypeId = entryType.typeDef.value.fields[0];
+          const valTypeId = entryType.typeDef.value.fields[1];
+          const keyTypeInfo = client.registry.findType(keyTypeId);
+          const valTypeInfo = client.registry.findType(valTypeId);
+          return {
+            keyType: {
+              typeId: keyTypeId,
+              typeName: keyTypeInfo.path?.join("::") || keyTypeInfo.typeDef.type || "Key",
+            },
+            valueType: {
+              typeId: valTypeId,
+              typeName: valTypeInfo.path?.join("::") || valTypeInfo.typeDef.type || "Value",
+            },
+          };
+        }
+      }
+      return { keyType: null, valueType: null };
+    } catch {
+      return { keyType: null, valueType: null };
+    }
+  }, [client, typeId]);
+
+  const emitChange = (newPairs: [unknown, unknown][]) => {
+    const filtered = newPairs.filter(([k, v]) => k !== undefined && v !== undefined);
+    onChange?.(filtered);
+  };
+
+  const handleAdd = () => {
+    const newPairs: [unknown, unknown][] = [...pairs, [undefined, undefined]];
+    setPairs(newPairs);
+    emitChange(newPairs);
+  };
+
+  const handleRemove = (index: number) => {
+    const newPairs = pairs.filter((_, i) => i !== index);
+    setPairs(newPairs.length === 0 ? [[undefined, undefined]] : newPairs);
+    emitChange(newPairs);
+  };
+
+  const handleKeyChange = (index: number, value: unknown) => {
+    const newPairs = [...pairs] as [unknown, unknown][];
+    newPairs[index] = [value, newPairs[index][1]];
+    setPairs(newPairs);
+    emitChange(newPairs);
+  };
+
+  const handleValueChange = (index: number, value: unknown) => {
+    const newPairs = [...pairs] as [unknown, unknown][];
+    newPairs[index] = [newPairs[index][0], value];
+    setPairs(newPairs);
+    emitChange(newPairs);
+  };
+
+  const keyResolved = keyType ? findComponent(keyType.typeName, keyType.typeId) : null;
+  const valueResolved = valueType ? findComponent(valueType.typeName, valueType.typeId) : null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <Label htmlFor={name}>
+          {label}
+          {isRequired && <span className="text-red-500 ml-1">*</span>}
+        </Label>
+        {!isDisabled && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleAdd}
+            className="flex items-center gap-1"
+          >
+            <Plus className="h-4 w-4" />
+            Add Entry
+          </Button>
+        )}
+      </div>
+      <div className="flex flex-col gap-2">
+        {pairs.map((_, index) => (
+          <Card key={index}>
+            <CardContent className="pt-4 pb-3 space-y-3">
+              <div className="flex items-start gap-2">
+                <div className="flex-1 space-y-3">
+                  {keyResolved ? (
+                    <keyResolved.component
+                      client={client}
+                      name={`${name}-key-${index}`}
+                      label="Key"
+                      typeId={keyType!.typeId}
+                      isDisabled={isDisabled}
+                      onChange={(v: unknown) => handleKeyChange(index, v)}
+                    />
+                  ) : (
+                    <input
+                      className="w-full rounded border px-2 py-1 text-sm font-mono"
+                      placeholder="Key"
+                      disabled={isDisabled}
+                      onChange={(e) => handleKeyChange(index, e.target.value)}
+                    />
+                  )}
+                  {valueResolved ? (
+                    <valueResolved.component
+                      client={client}
+                      name={`${name}-val-${index}`}
+                      label="Value"
+                      typeId={valueType!.typeId}
+                      isDisabled={isDisabled}
+                      onChange={(v: unknown) => handleValueChange(index, v)}
+                    />
+                  ) : (
+                    <input
+                      className="w-full rounded border px-2 py-1 text-sm font-mono"
+                      placeholder="Value"
+                      disabled={isDisabled}
+                      onChange={(e) => handleValueChange(index, e.target.value)}
+                    />
+                  )}
+                </div>
+                {!isDisabled && pairs.length > 1 && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleRemove(index)}
+                    className="mt-1"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      {description && <FormDescription>{description}</FormDescription>}
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}
+
+BTreeMap.schema = schema;

--- a/components/params/inputs/btree-set.tsx
+++ b/components/params/inputs/btree-set.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { z } from "zod";
+import { Label } from "@/components/ui/label";
+import { FormDescription } from "@/components/ui/form";
+import { Button } from "@/components/ui/button";
+import { Plus, Trash2 } from "lucide-react";
+import type { ParamInputProps } from "../types";
+import { findComponent } from "@/lib/input-map";
+
+interface BTreeSetProps extends ParamInputProps {
+  typeId: number;
+}
+
+const schema = z.array(z.any());
+
+export function BTreeSet({
+  name,
+  label,
+  description,
+  isDisabled,
+  isRequired,
+  error,
+  onChange,
+  client,
+  typeId,
+}: BTreeSetProps) {
+  const [items, setItems] = React.useState<unknown[]>([undefined]);
+  const [validationError, setValidationError] = React.useState<string | null>(null);
+
+  // Resolve inner type from registry
+  const innerType = React.useMemo(() => {
+    if (!client || typeId === undefined) return null;
+    try {
+      const typeInfo = client.registry.findType(typeId);
+      // BTreeSet is a Sequence in SCALE metadata
+      if (typeInfo.typeDef.type === "Sequence") {
+        const elemTypeId = typeInfo.typeDef.value.typeParam;
+        const elemType = client.registry.findType(elemTypeId);
+        return {
+          typeId: elemTypeId,
+          typeName: elemType.path?.join("::") || elemType.typeDef.type || "Item",
+        };
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }, [client, typeId]);
+
+  const emitChange = (newItems: unknown[]) => {
+    const defined = newItems.filter((item) => item !== undefined);
+    // Check for duplicates (basic string comparison)
+    const strings = defined.map((v) => JSON.stringify(v));
+    const unique = new Set(strings);
+    if (unique.size < strings.length) {
+      setValidationError("Set contains duplicate values");
+    } else {
+      setValidationError(null);
+    }
+    onChange?.(defined);
+  };
+
+  const handleAdd = () => {
+    const newItems = [...items, undefined];
+    setItems(newItems);
+    emitChange(newItems);
+  };
+
+  const handleRemove = (index: number) => {
+    const newItems = items.filter((_, i) => i !== index);
+    setItems(newItems.length === 0 ? [undefined] : newItems);
+    emitChange(newItems);
+  };
+
+  const handleItemChange = (index: number, value: unknown) => {
+    const newItems = [...items];
+    newItems[index] = value;
+    setItems(newItems);
+    emitChange(newItems);
+  };
+
+  const resolved = innerType ? findComponent(innerType.typeName, innerType.typeId) : null;
+  const displayError = validationError || error;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <Label htmlFor={name}>
+          {label}
+          {isRequired && <span className="text-red-500 ml-1">*</span>}
+        </Label>
+        {!isDisabled && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleAdd}
+            className="flex items-center gap-1"
+          >
+            <Plus className="h-4 w-4" />
+            Add Item
+          </Button>
+        )}
+      </div>
+      <div className="flex flex-col gap-2">
+        {items.map((_, index) => (
+          <div key={index} className="flex items-start gap-2">
+            <div className="flex-1">
+              {resolved ? (
+                <resolved.component
+                  client={client}
+                  name={`${name}-${index}`}
+                  label={`Item ${index}`}
+                  typeId={innerType!.typeId}
+                  isDisabled={isDisabled}
+                  onChange={(v: unknown) => handleItemChange(index, v)}
+                />
+              ) : (
+                <input
+                  className="w-full rounded border px-2 py-1 text-sm font-mono"
+                  placeholder={`Item ${index}`}
+                  disabled={isDisabled}
+                  onChange={(e) => handleItemChange(index, e.target.value)}
+                />
+              )}
+            </div>
+            {!isDisabled && items.length > 1 && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => handleRemove(index)}
+                className="mt-1"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        ))}
+      </div>
+      {description && <FormDescription>{description}</FormDescription>}
+      {displayError && <p className="text-sm text-red-500">{displayError}</p>}
+    </div>
+  );
+}
+
+BTreeSet.schema = schema;

--- a/components/params/inputs/bytes.tsx
+++ b/components/params/inputs/bytes.tsx
@@ -23,10 +23,21 @@ export function Bytes({
   isRequired,
   error,
   onChange,
+  value: externalValue,
 }: ParamInputProps) {
+  const [displayValue, setDisplayValue] = React.useState("");
+
+  React.useEffect(() => {
+    if (externalValue !== undefined && externalValue !== null) {
+      const str = String(externalValue);
+      if (str !== displayValue) setDisplayValue(str);
+    }
+  }, [externalValue]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value.trim().toLowerCase();
-    
+    setDisplayValue(value);
+
     // Add 0x prefix if not present and value is not empty
     const formattedValue = value && !value.startsWith("0x") ? `0x${value}` : value;
     onChange?.(formattedValue === "" ? undefined : formattedValue);
@@ -42,6 +53,7 @@ export function Bytes({
         id={name}
         type="text"
         disabled={isDisabled}
+        value={displayValue}
         onChange={handleChange}
         className="font-mono"
         placeholder="0x1234abcd"

--- a/components/params/inputs/enum.tsx
+++ b/components/params/inputs/enum.tsx
@@ -10,14 +10,16 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { ParamInputProps } from "../types";
+import { findComponent } from "@/lib/input-map";
 
 interface EnumVariant {
   name: string;
+  fields?: { typeId: number; typeName?: string; name?: string }[];
   component?: React.ReactNode;
 }
 
 interface EnumProps extends ParamInputProps {
-  variants: EnumVariant[];
+  variants?: EnumVariant[];
 }
 
 const schema = z.object({
@@ -33,16 +35,57 @@ export function Enum({
   isRequired,
   error,
   onChange,
-  variants,
+  value: externalValue,
+  variants: explicitVariants,
+  client,
+  typeId,
 }: EnumProps) {
   const [selectedVariant, setSelectedVariant] = React.useState<string | undefined>();
+
+  // Resolve variants from metadata if not explicitly provided
+  const variants = React.useMemo<EnumVariant[]>(() => {
+    if (explicitVariants && explicitVariants.length > 0) return explicitVariants;
+
+    if (!client || typeId === undefined) return [];
+
+    try {
+      const portableType = client.registry.findType(typeId);
+      const typeDef = portableType?.typeDef;
+      if (typeDef && typeDef.type === "Enum") {
+        return typeDef.value.members.map((member: any) => ({
+          name: member.name,
+          fields: member.fields?.map((f: any) => ({
+            typeId: f.typeId,
+            typeName: f.typeName,
+            name: f.name,
+          })),
+        }));
+      }
+    } catch {
+      // Type lookup failed
+    }
+    return [];
+  }, [explicitVariants, client, typeId]);
+
+  // Sync from external value (e.g., after hex decode sets { type: "Staked" })
+  React.useEffect(() => {
+    if (externalValue && typeof externalValue === "object" && "type" in externalValue) {
+      const variantName = (externalValue as { type: string }).type;
+      if (variantName !== selectedVariant) {
+        setSelectedVariant(variantName);
+      }
+    }
+  }, [externalValue]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleVariantChange = (value: string) => {
     setSelectedVariant(value);
     const variant = variants.find(v => v.name === value);
-    if (!variant?.component) {
+    // If variant has no fields (simple variant like "Staked"), emit immediately
+    if (!variant?.fields || variant.fields.length === 0) {
       onChange?.({ type: value });
     }
+    // If variant has an explicit component, don't emit yet (wait for sub-component)
+    // If variant has fields from metadata, don't emit yet (wait for sub-input)
   };
 
   const handleValueChange = (value: any) => {
@@ -51,18 +94,81 @@ export function Enum({
     }
   };
 
-  // Render the component for the selected variant if it exists
+  // Render the sub-component for the selected variant
   const renderVariantComponent = () => {
     const variant = variants.find(v => v.name === selectedVariant);
-    if (variant?.component && React.isValidElement(variant.component)) {
+    if (!variant) return null;
+
+    // If an explicit component was passed (legacy usage), use it
+    if (variant.component && React.isValidElement(variant.component)) {
       return React.cloneElement(variant.component as React.ReactElement<any>, {
         name: `${name}-value`,
         isDisabled: isDisabled,
         onChange: handleValueChange,
       });
     }
+
+    // If variant has fields from metadata, render dynamic sub-inputs
+    if (variant.fields && variant.fields.length > 0) {
+      // Single field: render inline
+      if (variant.fields.length === 1) {
+        const field = variant.fields[0];
+        const resolved = findComponent(field.typeName || "", field.typeId, client);
+        const SubComponent = resolved.component;
+        // Pass the inner value from externalValue if it exists
+        const innerValue = externalValue && typeof externalValue === "object" && "value" in externalValue
+          ? (externalValue as any).value
+          : undefined;
+        return (
+          <SubComponent
+            client={client}
+            name={`${name}-value`}
+            label={field.name || field.typeName || "Value"}
+            typeId={field.typeId}
+            typeName={field.typeName}
+            isDisabled={isDisabled}
+            value={innerValue}
+            onChange={handleValueChange}
+          />
+        );
+      }
+
+      // Multiple fields: render as a mini struct
+      return (
+        <div className="flex flex-col gap-2 ml-4 border-l-2 border-muted pl-4">
+          {variant.fields.map((field, idx) => {
+            const resolved = findComponent(field.typeName || "", field.typeId, client);
+            const SubComponent = resolved.component;
+            const fieldKey = field.name || `field_${idx}`;
+            return (
+              <SubComponent
+                key={fieldKey}
+                client={client}
+                name={`${name}-${fieldKey}`}
+                label={field.name || field.typeName || `Field ${idx}`}
+                typeId={field.typeId}
+                typeName={field.typeName}
+                isDisabled={isDisabled}
+                onChange={(val: unknown) => {
+                  // For multi-field variants, collect all field values as an object
+                  handleValueChange(val);
+                }}
+              />
+            );
+          })}
+        </div>
+      );
+    }
+
     return null;
   };
+
+  const hasSubComponent = React.useMemo(() => {
+    const variant = variants.find(v => v.name === selectedVariant);
+    if (!variant) return false;
+    if (variant.component) return true;
+    return variant.fields && variant.fields.length > 0;
+  }, [selectedVariant, variants]);
 
   return (
     <div className="flex flex-col gap-2">
@@ -86,7 +192,7 @@ export function Enum({
           ))}
         </SelectContent>
       </Select>
-      {selectedVariant && renderVariantComponent()}
+      {selectedVariant && hasSubComponent && renderVariantComponent()}
       {description && <FormDescription>{description}</FormDescription>}
       {error && <p className="text-sm text-red-500">{error}</p>}
     </div>

--- a/components/params/inputs/hash.tsx
+++ b/components/params/inputs/hash.tsx
@@ -39,10 +39,21 @@ export function Hash({
   isRequired,
   error,
   onChange,
+  value: externalValue,
   hashType,
 }: HashInputProps) {
+  const [displayValue, setDisplayValue] = React.useState("");
+
+  React.useEffect(() => {
+    if (externalValue !== undefined && externalValue !== null) {
+      const str = String(externalValue);
+      if (str !== displayValue) setDisplayValue(str);
+    }
+  }, [externalValue]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value.trim().toLowerCase();
+    setDisplayValue(value);
     onChange?.(value === "" ? undefined : value);
   };
 
@@ -67,6 +78,7 @@ export function Hash({
         id={name}
         type="text"
         disabled={isDisabled}
+        value={displayValue}
         onChange={handleChange}
         className="font-mono"
         placeholder={getPlaceholder()}

--- a/components/params/inputs/text.tsx
+++ b/components/params/inputs/text.tsx
@@ -18,8 +18,19 @@ export function Text({
   isRequired,
   error,
   onChange,
+  value: externalValue,
 }: ParamInputProps) {
+  const [displayValue, setDisplayValue] = React.useState("");
+
+  React.useEffect(() => {
+    if (externalValue !== undefined && externalValue !== null) {
+      const str = String(externalValue);
+      if (str !== displayValue) setDisplayValue(str);
+    }
+  }, [externalValue]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setDisplayValue(e.target.value);
     onChange?.(e.target.value);
   };
 
@@ -33,6 +44,7 @@ export function Text({
         id={name}
         type="text"
         disabled={isDisabled}
+        value={displayValue}
         onChange={handleChange}
         className={cn(
           "font-mono",

--- a/components/params/inputs/vector-fixed.tsx
+++ b/components/params/inputs/vector-fixed.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { z } from "zod";
+import { Label } from "@/components/ui/label";
+import { FormDescription } from "@/components/ui/form";
+import type { ParamInputProps } from "../types";
+import { findComponent } from "@/lib/input-map";
+
+interface VectorFixedProps extends ParamInputProps {
+  typeId: number;
+}
+
+const schema = z.array(z.any());
+
+export function VectorFixed({
+  name,
+  label,
+  description,
+  isDisabled,
+  isRequired,
+  error,
+  onChange,
+  client,
+  typeId,
+  typeName,
+}: VectorFixedProps) {
+  // Parse fixed length from typeName like "[u8; 32]"
+  const { length, innerTypeName } = React.useMemo(() => {
+    if (typeName) {
+      const match = typeName.match(/^\[(.+);\s*(\d+)\]$/);
+      if (match) {
+        return { innerTypeName: match[1].trim(), length: parseInt(match[2], 10) };
+      }
+    }
+    // Fallback: try to get from registry
+    if (client && typeId !== undefined) {
+      try {
+        const typeInfo = client.registry.findType(typeId);
+        if (typeInfo.typeDef.type === "SizedVec") {
+          const len = typeInfo.typeDef.value.len;
+          const elemTypeId = typeInfo.typeDef.value.typeParam;
+          const elemType = client.registry.findType(elemTypeId);
+          const elemName = elemType.path?.join("::") || elemType.typeDef.type || "Element";
+          return { innerTypeName: elemName, length: len };
+        }
+      } catch {
+        // fallback
+      }
+    }
+    return { innerTypeName: "unknown", length: 0 };
+  }, [typeName, client, typeId]);
+
+  const [values, setValues] = React.useState<unknown[]>(() =>
+    new Array(length).fill(undefined)
+  );
+
+  // Reset when length changes
+  React.useEffect(() => {
+    if (length > 0 && values.length !== length) {
+      setValues(new Array(length).fill(undefined));
+    }
+  }, [length, values.length]);
+
+  const handleItemChange = (index: number, value: unknown) => {
+    const newValues = [...values];
+    newValues[index] = value;
+    setValues(newValues);
+    onChange?.(newValues);
+  };
+
+  const resolved = innerTypeName ? findComponent(innerTypeName) : null;
+
+  if (length === 0) {
+    return (
+      <div className="flex flex-col gap-2">
+        <Label htmlFor={name}>
+          {label}
+          {isRequired && <span className="text-red-500 ml-1">*</span>}
+        </Label>
+        <p className="text-sm text-muted-foreground">
+          Unable to resolve fixed array structure
+        </p>
+        {error && <p className="text-sm text-red-500">{error}</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <Label htmlFor={name}>
+          {label}
+          {isRequired && <span className="text-red-500 ml-1">*</span>}
+        </Label>
+        <span className="text-xs text-muted-foreground">
+          ({length} elements)
+        </span>
+      </div>
+      <div className="flex flex-col gap-2">
+        {Array.from({ length }, (_, index) => (
+          <div key={index} className="flex-1">
+            {resolved ? (
+              <resolved.component
+                client={client}
+                name={`${name}-${index}`}
+                label={`[${index}]`}
+                typeId={typeId}
+                isDisabled={isDisabled}
+                onChange={(v: unknown) => handleItemChange(index, v)}
+              />
+            ) : (
+              <input
+                className="w-full rounded border px-2 py-1 text-sm font-mono"
+                placeholder={`Element ${index}`}
+                disabled={isDisabled}
+                onChange={(e) => handleItemChange(index, e.target.value)}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+      {description && <FormDescription>{description}</FormDescription>}
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}
+
+VectorFixed.schema = schema;

--- a/components/params/types.ts
+++ b/components/params/types.ts
@@ -6,11 +6,13 @@ export interface ParamInputProps {
   name: string;
   label?: string;
   description?: string;
+  typeName?: string;
   isDisabled?: boolean;
   isRequired?: boolean;
   error?: string;
   client: DedotClient<PolkadotApi>;
   typeId?: number;
+  value?: any;
   onChange?: (value: unknown) => void;
 }
 

--- a/components/sections/extrinsic-builder.tsx
+++ b/components/sections/extrinsic-builder.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion, useScroll, useTransform } from "framer-motion";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -463,10 +464,12 @@ export function ExtrinsicBuilderSection() {
             <DemoPreview />
 
             <div className="absolute -bottom-20 left-1/2 -translate-x-1/2">
-              <Button size="lg" className="rounded-full">
-                Try Builder (It&apos;s Free){" "}
-                <ArrowRight className="ml-2 h-4 w-4" />
-              </Button>
+              <Link href="/builder">
+                <Button size="lg" className="rounded-full">
+                  Try Builder (It&apos;s Free){" "}
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Button>
+              </Link>
             </div>
           </motion.div>
         </div>

--- a/components/shared/chain-selector.tsx
+++ b/components/shared/chain-selector.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useSwitchChain } from "@luno-kit/react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export function ChainSelector() {
+  const { chains, currentChain, switchChain } = useSwitchChain();
+
+  const handleChange = (chainId: string) => {
+    switchChain({ chainId });
+  };
+
+  return (
+    <Select
+      value={currentChain?.genesisHash ?? ""}
+      onValueChange={handleChange}
+    >
+      <SelectTrigger className="w-[140px] h-9 text-xs font-medium">
+        <SelectValue placeholder="Select chain" />
+      </SelectTrigger>
+      <SelectContent>
+        {chains.map((chain) => (
+          <SelectItem
+            key={chain.genesisHash}
+            value={chain.genesisHash}
+            className="text-xs"
+          >
+            <span className="flex items-center gap-2">
+              {chain.name}
+              {chain.testnet && (
+                <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">
+                  testnet
+                </span>
+              )}
+            </span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/config/wallet.ts
+++ b/config/wallet.ts
@@ -1,5 +1,5 @@
 import { createConfig } from "@luno-kit/react";
-import { polkadot, kusama } from "@luno-kit/react/chains";
+import { polkadot, kusama, westend } from "@luno-kit/react/chains";
 import {
   polkadotjsConnector,
   talismanConnector,
@@ -8,7 +8,7 @@ import {
 
 export const walletConfig = createConfig({
   appName: "Relaycode",
-  chains: [polkadot, kusama],
+  chains: [polkadot, kusama, westend],
   connectors: [
     polkadotjsConnector(),
     talismanConnector(),

--- a/context/client.tsx
+++ b/context/client.tsx
@@ -37,14 +37,16 @@ export const ClientProvider = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     let cancelled = false;
 
+    // Immediately clear client and show loading when chain changes
+    setClient(null);
+    setLoading(true);
+
     const connect = async () => {
       // Disconnect previous client
       if (clientRef.current) {
         await clientRef.current.disconnect();
         clientRef.current = null;
       }
-
-      setLoading(true);
       try {
         const newClient = await DedotClient.new<PolkadotApi>(
           new WsProvider(rpcUrl)


### PR DESCRIPTION
## Summary
- Add 4 new input components: BTreeMap, BTreeSet, VectorFixed, ChainSelector
- Enhance Account (wallet integration), Balance (denomination/ED), Amount (Compact denominations), Enum (metadata variants), Vector (metadata resolution), Hash (H160/H512)
- Improve information pane error handling: skip errors on empty fields, clear stale errors after decode, re-populate hex after call data decode
- Expand input registry with path-based fallback resolution and metadata-driven type detection

## Test plan
- [ ] Verify new BTreeMap/BTreeSet/VectorFixed components render and accept input
- [ ] Verify Account input shows wallet accounts and recent addresses
- [ ] Verify Balance denomination switching and Max button
- [ ] Verify Enum resolves variants from metadata
- [ ] Verify info pane doesn't show errors on untouched fields
- [ ] Run `yarn test` — all 173 tests pass
- [ ] Run `yarn build` — production build succeeds