### PR TITLE
Add 1:1 hex pane mirroring and smart bytes input

### DIFF
--- a/__tests__/lib/codec-decompose.test.ts
+++ b/__tests__/lib/codec-decompose.test.ts
@@ -1,0 +1,73 @@
+import { patchValueAtPath, HexLeafNode, HexCompoundNode } from "@/lib/codec";
+
+describe("patchValueAtPath", () => {
+  it("returns newValue when path is empty", () => {
+    expect(patchValueAtPath("old", [], "new")).toBe("new");
+    expect(patchValueAtPath(42, [], "replaced")).toBe("replaced");
+  });
+
+  it("patches a top-level array index", () => {
+    const root = ["a", "b", "c"];
+    const result = patchValueAtPath(root, [1], "B") as string[];
+    expect(result).toEqual(["a", "B", "c"]);
+    // Immutability: original unchanged
+    expect(root).toEqual(["a", "b", "c"]);
+  });
+
+  it("patches a top-level object key", () => {
+    const root = { foo: 1, bar: 2 };
+    const result = patchValueAtPath(root, ["foo"], 99) as Record<string, number>;
+    expect(result).toEqual({ foo: 99, bar: 2 });
+    expect(root).toEqual({ foo: 1, bar: 2 });
+  });
+
+  it("patches a nested path [number, string]", () => {
+    const root = [{ name: "Alice" }, { name: "Bob" }];
+    const result = patchValueAtPath(root, [1, "name"], "Charlie");
+    expect(result).toEqual([{ name: "Alice" }, { name: "Charlie" }]);
+  });
+
+  it("patches a deep nested path", () => {
+    const root = { a: [{ b: { c: "old" } }] };
+    const result = patchValueAtPath(root, ["a", 0, "b", "c"], "new");
+    expect(result).toEqual({ a: [{ b: { c: "new" } }] });
+  });
+
+  it("creates intermediate arrays for number keys on undefined", () => {
+    const root = undefined;
+    const result = patchValueAtPath(root, [2], "val");
+    expect(result).toEqual([undefined, undefined, "val"]);
+  });
+
+  it("creates intermediate objects for string keys on undefined", () => {
+    const root = undefined;
+    const result = patchValueAtPath(root, ["x", "y"], "val");
+    expect(result).toEqual({ x: { y: "val" } });
+  });
+
+  it("handles mixed path on null root", () => {
+    const result = patchValueAtPath(null, ["arr", 0], "val");
+    expect(result).toEqual({ arr: ["val"] });
+  });
+});
+
+describe("HexTreeNode types", () => {
+  it("leaf node shape", () => {
+    const leaf: HexLeafNode = { kind: "leaf" };
+    expect(leaf.kind).toBe("leaf");
+  });
+
+  it("compound node shape", () => {
+    const compound: HexCompoundNode = {
+      kind: "compound",
+      compoundType: "Sequence",
+      children: [
+        { label: "[0]", typeId: 1, hex: "0x01" },
+        { label: "[1]", typeId: 1, hex: "0x02", children: { kind: "leaf" } },
+      ],
+    };
+    expect(compound.kind).toBe("compound");
+    expect(compound.children).toHaveLength(2);
+    expect(compound.children[1].children?.kind).toBe("leaf");
+  });
+});

--- a/components/builder/field-hex-display.tsx
+++ b/components/builder/field-hex-display.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import React from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Copy, Check, AlertCircle } from "lucide-react";
+import { stringCamelCase } from "dedot/utils";
+import type { HexTreeNode } from "@/lib/codec";
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = React.useState(false);
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="ml-2 p-1 text-gray-400 hover:text-gray-600 transition-colors"
+      title="Copy to clipboard"
+    >
+      {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+    </button>
+  );
+}
+
+interface FieldHexDisplayProps {
+  fieldName: string;
+  typeName?: string;
+  hex: string;
+  decomposition: HexTreeNode;
+  editing: boolean;
+  error?: string | null;
+  hasError?: boolean;
+  onHexChange: (hex: string) => void;
+  onSubHexChange?: (path: (string | number)[], hex: string, typeId: number) => void;
+}
+
+export const FieldHexDisplay: React.FC<FieldHexDisplayProps> = ({
+  fieldName,
+  typeName,
+  hex,
+  decomposition,
+  editing,
+  error,
+  hasError,
+  onHexChange,
+  onSubHexChange,
+}) => {
+  if (decomposition.kind === "leaf") {
+    return (
+      <div>
+        <div className="flex items-center justify-between">
+          <Label className="text-sm font-medium">
+            {stringCamelCase(fieldName)} Hex
+          </Label>
+          {typeName && (
+            <span className="text-xs text-gray-400 font-mono">{typeName}</span>
+          )}
+        </div>
+        <div className="flex items-center">
+          <Input
+            value={hex || "0x"}
+            onChange={(e) => onHexChange(e.target.value)}
+            disabled={!editing}
+            className={`font-mono text-blue-500 ${hasError ? "border-red-500" : ""}`}
+          />
+          {hex && hex !== "0x" && <CopyButton text={hex} />}
+        </div>
+        {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
+      </div>
+    );
+  }
+
+  // Compound node — render parent label + children
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <Label className="text-sm font-medium">
+          {stringCamelCase(fieldName)} Hex
+        </Label>
+        {typeName && (
+          <span className="text-xs text-gray-400 font-mono">{typeName}</span>
+        )}
+      </div>
+      {/* Top-level (concatenated) hex — read-only, for reference */}
+      <div className="flex items-center">
+        <Input
+          value={hex || "0x"}
+          onChange={(e) => onHexChange(e.target.value)}
+          disabled={!editing}
+          className={`font-mono text-blue-500 ${hasError ? "border-red-500" : ""}`}
+        />
+        {hex && hex !== "0x" && <CopyButton text={hex} />}
+      </div>
+      {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
+
+      {/* Per-element sub-hex inputs */}
+      <div className="ml-4 border-l-2 border-muted pl-3 mt-2 space-y-2">
+        {decomposition.children.map((child, i) => {
+          const childLabel = `${stringCamelCase(fieldName)}${child.label}`;
+          const childPath = buildPath(child.label, decomposition.compoundType);
+
+          return (
+            <SubHexNode
+              key={i}
+              label={childLabel}
+              child={child}
+              path={childPath}
+              editing={editing}
+              onSubHexChange={onSubHexChange}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+interface SubHexNodeProps {
+  label: string;
+  child: { label: string; typeId: number; hex: string; children?: HexTreeNode };
+  path: (string | number)[];
+  editing: boolean;
+  onSubHexChange?: (path: (string | number)[], hex: string, typeId: number) => void;
+}
+
+const SubHexNode: React.FC<SubHexNodeProps> = ({
+  label,
+  child,
+  path,
+  editing,
+  onSubHexChange,
+}) => {
+  const node = child.children;
+
+  // If this child has its own compound children, recurse
+  if (node && node.kind === "compound") {
+    return (
+      <div>
+        <Label className="text-xs font-medium text-muted-foreground">
+          {label} Hex
+        </Label>
+        <div className="flex items-center">
+          <Input
+            value={child.hex || "0x"}
+            onChange={(e) => onSubHexChange?.(path, e.target.value, child.typeId)}
+            disabled={!editing}
+            className="font-mono text-blue-400 text-sm h-8"
+          />
+          {child.hex && child.hex !== "0x" && <CopyButton text={child.hex} />}
+        </div>
+        <div className="ml-4 border-l-2 border-muted pl-3 mt-1 space-y-1">
+          {node.children.map((grandchild, j) => {
+            const grandchildLabel = `${label}${grandchild.label}`;
+            const grandchildPath = [...path, ...buildPath(grandchild.label, node.compoundType)];
+            return (
+              <SubHexNode
+                key={j}
+                label={grandchildLabel}
+                child={grandchild}
+                path={grandchildPath}
+                editing={editing}
+                onSubHexChange={onSubHexChange}
+              />
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  // Leaf sub-node
+  return (
+    <div>
+      <Label className="text-xs font-medium text-muted-foreground">
+        {label} Hex
+      </Label>
+      <div className="flex items-center">
+        <Input
+          value={child.hex || "0x"}
+          onChange={(e) => onSubHexChange?.(path, e.target.value, child.typeId)}
+          disabled={!editing}
+          className="font-mono text-blue-400 text-sm h-8"
+        />
+        {child.hex && child.hex !== "0x" && <CopyButton text={child.hex} />}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Convert a child label into a path segment for patchValueAtPath.
+ * "[0]" → [0], "fieldName" → ["fieldName"], "VariantName" (Enum) → ["value"]
+ */
+function buildPath(label: string, compoundType: string): (string | number)[] {
+  // Array index: [0], [1], etc.
+  const indexMatch = label.match(/^\[(\d+)\]$/);
+  if (indexMatch) return [parseInt(indexMatch[1], 10)];
+
+  // Enum variant: the path into enum form value is through "value"
+  if (compoundType === "Enum") return ["value"];
+
+  // Struct field or other named path
+  return [label];
+}

--- a/components/params/inputs/bytes.tsx
+++ b/components/params/inputs/bytes.tsx
@@ -1,19 +1,52 @@
-import React from "react";
+import React, { useRef } from "react";
 import { z } from "zod";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import { FormDescription } from "@/components/ui/form";
+import { Button } from "@/components/ui/button";
 import type { ParamInputProps } from "../types";
 import { isHex } from "dedot/utils";
+import { Upload } from "lucide-react";
+
+type InputMode = "hex" | "text" | "file";
 
 const schema = z.string().refine((value) => {
-  // Allow empty string
   if (value === "") return true;
-  // Must be hex string with 0x prefix and even length
   return isHex(value) && value.length % 2 === 0;
 }, {
   message: "Invalid bytes (must be hex string with 0x prefix and even length)",
 });
+
+function bytesToHex(bytes: Uint8Array): string {
+  if (bytes.length === 0) return "";
+  return "0x" + Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function hexToBytes(hex: string): Uint8Array | null {
+  const stripped = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (stripped.length === 0) return new Uint8Array(0);
+  if (stripped.length % 2 !== 0) return null;
+  if (!/^[0-9a-fA-F]+$/.test(stripped)) return null;
+  const bytes = new Uint8Array(stripped.length / 2);
+  for (let i = 0; i < stripped.length; i += 2) {
+    bytes[i / 2] = parseInt(stripped.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+function tryDecodeUtf8(hex: string): string | null {
+  const bytes = hexToBytes(hex);
+  if (!bytes || bytes.length === 0) return null;
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    // Reject if it contains control characters (except newline/tab) — likely binary
+    if (/[\x00-\x08\x0B\x0C\x0E-\x1F]/.test(text)) return null;
+    return text;
+  } catch {
+    return null;
+  }
+}
 
 export function Bytes({
   name,
@@ -25,40 +58,159 @@ export function Bytes({
   onChange,
   value: externalValue,
 }: ParamInputProps) {
-  const [displayValue, setDisplayValue] = React.useState("");
+  const [mode, setMode] = React.useState<InputMode>("hex");
+  const [hexValue, setHexValue] = React.useState("");
+  const [textValue, setTextValue] = React.useState("");
+  const [fileName, setFileName] = React.useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Sync from external value (decode flow)
   React.useEffect(() => {
     if (externalValue !== undefined && externalValue !== null) {
       const str = String(externalValue);
-      if (str !== displayValue) setDisplayValue(str);
+      if (str !== hexValue) {
+        setHexValue(str);
+        // Try to decode as UTF-8 text for text mode sync
+        const decoded = tryDecodeUtf8(str);
+        if (decoded !== null) {
+          setTextValue(decoded);
+        }
+        setFileName(null);
+      }
     }
   }, [externalValue]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.trim().toLowerCase();
-    setDisplayValue(value);
-
-    // Add 0x prefix if not present and value is not empty
-    const formattedValue = value && !value.startsWith("0x") ? `0x${value}` : value;
-    onChange?.(formattedValue === "" ? undefined : formattedValue);
+  const emitHex = (hex: string) => {
+    setHexValue(hex);
+    onChange?.(hex === "" ? undefined : hex);
   };
+
+  const handleHexChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value.trim().toLowerCase();
+    const formatted = val && !val.startsWith("0x") ? `0x${val}` : val;
+    setHexValue(formatted);
+    // Sync text display
+    const decoded = tryDecodeUtf8(formatted);
+    if (decoded !== null) setTextValue(decoded);
+    onChange?.(formatted === "" ? undefined : formatted);
+  };
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const text = e.target.value;
+    setTextValue(text);
+    setFileName(null);
+    if (text === "") {
+      emitHex("");
+      return;
+    }
+    const encoded = new TextEncoder().encode(text);
+    emitHex(bytesToHex(encoded));
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setFileName(file.name);
+    const reader = new FileReader();
+    reader.onload = () => {
+      const buffer = reader.result as ArrayBuffer;
+      const bytes = new Uint8Array(buffer);
+      const hex = bytesToHex(bytes);
+      setTextValue("");
+      emitHex(hex);
+    };
+    reader.readAsArrayBuffer(file);
+  };
+
+  const byteCount = hexValue && hexValue.startsWith("0x") && hexValue.length > 2
+    ? (hexValue.length - 2) / 2
+    : 0;
 
   return (
     <div className="flex flex-col gap-2">
-      <Label htmlFor={name}>
-        {label}
-        {isRequired && <span className="text-red-500 ml-1">*</span>}
-      </Label>
-      <Input
-        id={name}
-        type="text"
-        disabled={isDisabled}
-        value={displayValue}
-        onChange={handleChange}
-        className="font-mono"
-        placeholder="0x1234abcd"
-      />
-      {description && <FormDescription>{description}</FormDescription>}
+      <div className="flex items-center justify-between">
+        <Label htmlFor={name}>
+          {label}
+          {isRequired && <span className="text-red-500 ml-1">*</span>}
+        </Label>
+        <div className="flex gap-1">
+          {(["hex", "text", "file"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              disabled={isDisabled}
+              className={`px-2 py-0.5 text-xs rounded-full border transition-colors ${
+                mode === m
+                  ? "bg-primary text-primary-foreground border-primary"
+                  : "bg-background text-muted-foreground border-input hover:bg-accent"
+              }`}
+            >
+              {m === "hex" ? "Hex" : m === "text" ? "Text" : "File"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {mode === "hex" && (
+        <Input
+          id={name}
+          type="text"
+          disabled={isDisabled}
+          value={hexValue}
+          onChange={handleHexChange}
+          className="font-mono"
+          placeholder="0x1234abcd"
+        />
+      )}
+
+      {mode === "text" && (
+        <Textarea
+          id={name}
+          disabled={isDisabled}
+          value={textValue}
+          onChange={handleTextChange}
+          className="font-mono min-h-[80px]"
+          placeholder="Enter text (auto-converts to hex)"
+        />
+      )}
+
+      {mode === "file" && (
+        <div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            onChange={handleFileChange}
+            className="hidden"
+            disabled={isDisabled}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={isDisabled}
+            onClick={() => fileInputRef.current?.click()}
+            className="w-full justify-center gap-2"
+          >
+            <Upload className="h-4 w-4" />
+            {fileName || "Choose file"}
+          </Button>
+          {fileName && hexValue && (
+            <p className="text-xs text-muted-foreground mt-1 font-mono truncate">
+              {hexValue.slice(0, 42)}{hexValue.length > 42 ? "..." : ""}
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between">
+        {description && <FormDescription>{description}</FormDescription>}
+        {byteCount > 0 && (
+          <span className="text-xs text-muted-foreground">
+            {byteCount} byte{byteCount !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
       {error && <p className="text-sm text-red-500">{error}</p>}
     </div>
   );


### PR DESCRIPTION
## Summary
- **Hex pane decomposition**: Information pane now mirrors form inputs 1:1 — compound types (Vec, Struct, Enum, Tuple) show per-element hex (e.g. `targets[0] Hex`, `targets[1] Hex`) instead of one blob
- **Smart bytes input**: Bytes (`Vec<u8>`) now supports three input modes — Hex, Text (UTF-8), and File upload — all emitting consistent hex to the encoder
- **Bidirectional sub-hex editing**: Editing a sub-element's hex decodes it and patches the corresponding form input

## Test plan
- [ ] `yarn test` — all tests pass (including new patchValueAtPath tests)
- [ ] `yarn build` — production build succeeds
- [ ] Staking.nominate: info pane shows `targets[0] Hex`, `targets[1] Hex` individually
- [ ] Staking.bond: `value Hex` + `payee Hex` shown individually (leaf nodes)
- [ ] System.remark: type "Hello" in text mode → hex appears in info pane
- [ ] File upload in Bytes → hex appears correctly
- [ ] Edit a sub-hex → corresponding form input updates