### PR TITLE
Update M2 documentation

### DIFF
--- a/docs/api/input-map.md
+++ b/docs/api/input-map.md
@@ -50,10 +50,12 @@ The system uses a priority-based registry to match types. Higher priority patter
 | Priority | Component | Patterns |
 |----------|-----------|----------|
 | 100 | Account | `AccountId`, `AccountId32`, `AccountId20`, `MultiAddress`, `Address`, `LookupSource`, `/^AccountId/`, `/^MultiAddress/` |
-| 95 | Balance | `Balance`, `BalanceOf`, `/^Balance/` |
+| 95 | Balance | `Balance`, `BalanceOf`, `Compact<Balance>`, `Compact<BalanceOf>`, `/^Balance/` |
 | 90 | Amount | `Compact<u128>`, `Compact<u64>`, `u128`, `u64`, `u32`, `u16`, `u8`, `i128`, `i64`, `i32`, `i16`, `i8`, `/Compact</` |
 | 85 | Boolean | `bool` |
+| 82 | Hash160 | `H160`, `/^H160$/` |
 | 80 | Hash256 | `H256`, `Hash`, `/H256/`, `/Hash/` |
+| 78 | Hash512 | `H512`, `/^H512$/` |
 | 75 | Bytes | `Bytes`, `Vec<u8>`, `/Bytes/` |
 | 70 | Call | `Call`, `RuntimeCall`, `/Call$/`, `/RuntimeCall>/` |
 | 65 | Moment | `Moment`, `/Moment/` |
@@ -61,6 +63,9 @@ The system uses a priority-based registry to match types. Higher priority patter
 | 55 | VoteThreshold | `VoteThreshold`, `/VoteThreshold/` |
 | 50 | KeyValue | `KeyValue`, `/KeyValue/` |
 | 45 | Option | `/^Option</` |
+| 43 | VectorFixed | `/^\[.+;\s*\d+\]$/` (e.g., `[u8; 32]`) |
+| 42 | BTreeMap | `/^BTreeMap</` |
+| 41 | BTreeSet | `/^BTreeSet</` |
 | 40 | Vector | `/^Vec</`, `/^BoundedVec</` |
 | 38 | Tuple | `/^\(/`, `/^Tuple/` |
 | 35 | Struct | (no patterns - fallback for composite types) |
@@ -77,14 +82,20 @@ The system checks patterns in priority order, returning the first match.
 
 **Example matches:**
 ```typescript
-findComponent("AccountId");       // → Account (exact match, priority 100)
-findComponent("AccountIdOf<T>");  // → Account (regex match, priority 100)
-findComponent("Balance");         // → Balance (exact match, priority 95)
-findComponent("BalanceOf<T>");    // → Balance (regex match, priority 95)
-findComponent("Vec<u8>");         // → Bytes (exact match, priority 75)
-findComponent("Vec<AccountId>");  // → Vector (regex match, priority 40)
-findComponent("Option<Balance>"); // → Option (regex match, priority 45)
-findComponent("UnknownType");     // → Text (fallback)
+findComponent("AccountId");              // → Account (exact match, priority 100)
+findComponent("AccountIdOf<T>");         // → Account (regex match, priority 100)
+findComponent("Balance");                // → Balance (exact match, priority 95)
+findComponent("Compact<Balance>");       // → Balance (exact match, priority 95)
+findComponent("BalanceOf<T>");           // → Balance (regex match, priority 95)
+findComponent("H160");                   // → Hash160 (exact match, priority 82)
+findComponent("H512");                   // → Hash512 (exact match, priority 78)
+findComponent("Vec<u8>");               // → Bytes (exact match, priority 75)
+findComponent("[u8; 32]");              // → VectorFixed (regex match, priority 43)
+findComponent("BTreeMap<u32, u64>");    // → BTreeMap (regex match, priority 42)
+findComponent("BTreeSet<AccountId>");   // → BTreeSet (regex match, priority 41)
+findComponent("Vec<AccountId>");        // → Vector (regex match, priority 40)
+findComponent("Option<Balance>");       // → Option (regex match, priority 45)
+findComponent("UnknownType");           // → Text (fallback)
 ```
 
 ## Component Registration
@@ -226,11 +237,17 @@ Common Substrate type patterns and their expected components:
 | `AccountId`, `AccountId32` | Account | SS58 address input |
 | `MultiAddress` | Account | Supports Id, Index, Raw variants |
 | `Balance`, `BalanceOf<T>` | Balance | With denomination selector |
+| `Compact<Balance>`, `Compact<BalanceOf>` | Balance | Compact-wrapped balances get denomination support |
 | `Compact<u128>` | Amount | Integer input |
 | `u32`, `u64`, `u128` | Amount | Unsigned integers |
 | `bool` | Boolean | Toggle switch |
+| `H160` | Hash160 | 20-byte hex input |
 | `H256`, `BlockHash` | Hash256 | 32-byte hex input |
+| `H512` | Hash512 | 64-byte hex input |
 | `Vec<u8>`, `Bytes` | Bytes | Hex byte array |
+| `[T; N]` | VectorFixed | Fixed-length array (e.g., `[u8; 32]`) |
+| `BTreeMap<K, V>` | BTreeMap | Key-value pair list |
+| `BTreeSet<T>` | BTreeSet | Unique value set |
 | `Vec<T>` | Vector | Dynamic array |
 | `Option<T>` | Option | Optional with toggle |
 | `(T1, T2, ...)` | Tuple | Positional elements |

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -10,21 +10,28 @@ All input components live in `components/params/inputs/` and share a common inte
 
 ```
 components/params/
-├── types.ts           # ParamInputProps interface
+├── types.ts              # ParamInputProps interface
 └── inputs/
-    ├── account.tsx    # SS58 address input
-    ├── amount.tsx     # Integer numeric input
-    ├── balance.tsx    # Token amount with denominations
-    ├── boolean.tsx    # Boolean toggle
-    ├── bytes.tsx      # Hex byte array
-    ├── call.tsx       # Nested extrinsic builder
-    ├── enum.tsx       # Variant selector
-    ├── hash.tsx       # H256/H160/H512 input
-    ├── option.tsx     # Optional value wrapper
-    ├── struct.tsx     # Composite type container
-    ├── text.tsx       # String/fallback input
-    ├── tuple.tsx      # Positional collection
-    └── vector.tsx     # Dynamic array
+    ├── account.tsx       # SS58 address input
+    ├── amount.tsx        # Integer numeric input
+    ├── balance.tsx       # Token amount with denominations
+    ├── boolean.tsx       # Boolean toggle
+    ├── btree-map.tsx     # BTreeMap key-value pairs
+    ├── btree-set.tsx     # BTreeSet unique values
+    ├── bytes.tsx         # Hex byte array
+    ├── call.tsx          # Nested extrinsic builder
+    ├── enum.tsx          # Variant selector
+    ├── hash.tsx          # H160/H256/H512 input
+    ├── key-value.tsx     # Key-value pair
+    ├── moment.tsx        # Timestamp input
+    ├── option.tsx        # Optional value wrapper
+    ├── struct.tsx        # Composite type container
+    ├── text.tsx          # String/fallback input
+    ├── tuple.tsx         # Positional collection
+    ├── vector.tsx        # Dynamic array
+    ├── vector-fixed.tsx  # Fixed-length array
+    ├── vote.tsx          # Vote input
+    └── vote-threshold.tsx # Vote threshold input
 ```
 
 ### ParamInputProps Interface
@@ -36,6 +43,7 @@ interface ParamInputProps {
   name: string;                    // Field identifier
   label?: string;                  // Display label
   description?: string;            // Help text
+  typeName?: string;               // Substrate type name (e.g., "Balance", "AccountId")
   isDisabled?: boolean;            // Disable input
   isRequired?: boolean;            // Show required indicator
   error?: string;                  // Error message to display
@@ -74,12 +82,17 @@ Amount.schema = schema;
 
 ### Binary Types
 - [BytesInput](./inputs.md#bytesinput) - Byte arrays
-- [HashInput](./inputs.md#hashinput) - Fixed-size hashes
+- [HashInput](./inputs.md#hashinput) - Fixed-size hashes (H160, H256, H512)
+
+### Collection Types
+- [VectorInput](./inputs.md#vectorinput) - Dynamic arrays (`Vec<T>`)
+- [VectorFixedInput](./inputs.md#vectorfixedinput) - Fixed-length arrays (`[T; N]`)
+- [BTreeMapInput](./inputs.md#btreemapinput) - Key-value maps (`BTreeMap<K, V>`)
+- [BTreeSetInput](./inputs.md#btreesetinput) - Unique value sets (`BTreeSet<T>`)
 
 ### Composite Types
 - [StructInput](./inputs.md#structinput) - Named field objects
 - [TupleInput](./inputs.md#tupleinput) - Positional arrays
-- [VectorInput](./inputs.md#vectorinput) - Dynamic arrays
 - [OptionInput](./inputs.md#optioninput) - Optional values
 - [EnumInput](./inputs.md#enuminput) - Variant types
 
@@ -118,11 +131,14 @@ Components call `onChange` with the appropriate value type:
 | Amount | `string` (integer as string) |
 | Balance | `string` (planck value as string) |
 | Boolean | `boolean` |
+| BTreeMap | `[unknown, unknown][]` (array of key-value tuples) |
+| BTreeSet | `unknown[]` (array of unique values) |
 | Bytes | `string` (hex with 0x) |
 | Hash | `string` (hex with 0x) |
 | Text | `string` |
 | Option | `undefined` or inner value |
 | Vector | `unknown[]` |
+| VectorFixed | `unknown[]` (fixed-length array) |
 | Struct | `Record<string, unknown>` |
 | Tuple | `unknown[]` |
 | Enum | `{ type: string; value?: unknown }` |

--- a/docs/components/inputs.md
+++ b/docs/components/inputs.md
@@ -91,7 +91,7 @@ Standard `ParamInputProps` interface.
 
 **File:** `components/params/inputs/balance.tsx`
 
-**Handles:** `Balance`, `BalanceOf`
+**Handles:** `Balance`, `BalanceOf`, `Compact<Balance>`, `Compact<BalanceOf>`
 
 Token amount input with denomination selector and wallet balance display.
 
@@ -574,6 +574,121 @@ interface VectorProps extends ParamInputProps {
 │ [5FHneW46...A9Yq                            ▾] [🗑]  │
 │ [Select account...                          ▾] [🗑]  │
 └─────────────────────────────────────────────────────┘
+```
+
+---
+
+## VectorFixedInput
+
+**File:** `components/params/inputs/vector-fixed.tsx`
+
+**Handles:** `[T; N]` (fixed-length arrays, e.g., `[u8; 32]`, `[AccountId; 3]`)
+
+Fixed-length array input with a predetermined number of elements.
+
+### Features
+- Parses length from type name (`[T; N]` syntax) or from registry (`SizedVec`)
+- Renders exactly N input fields — no add/remove
+- Each element uses the appropriate typed input component
+- Shows element count indicator
+
+### Props
+Extended interface:
+```typescript
+interface VectorFixedProps extends ParamInputProps {
+  typeId: number;
+}
+```
+
+### Value Type
+`unknown[]` - Fixed-length array of element values
+
+### Example Usage
+```tsx
+<VectorFixed
+  client={client}
+  name="data"
+  label="Fixed Data"
+  typeName="[u8; 32]"
+  typeId={typeId}
+  onChange={(values) => console.log(values)}
+/>
+```
+
+---
+
+## BTreeMapInput
+
+**File:** `components/params/inputs/btree-map.tsx`
+
+**Handles:** `BTreeMap<K, V>`
+
+Key-value pair list with typed inner inputs for both keys and values.
+
+### Features
+- Add/remove key-value pairs dynamically
+- Resolves key and value types from chain registry (BTreeMap is a `Sequence` of `Tuple`s in SCALE)
+- Each pair renders typed inputs for key and value
+- Card-based layout for each entry
+
+### Props
+Extended interface:
+```typescript
+interface BTreeMapProps extends ParamInputProps {
+  typeId: number;
+}
+```
+
+### Value Type
+`[unknown, unknown][]` - Array of key-value tuples
+
+### Example Usage
+```tsx
+<BTreeMap
+  client={client}
+  name="metadata"
+  label="Metadata"
+  typeId={typeId}
+  onChange={(pairs) => console.log(pairs)}
+/>
+```
+
+---
+
+## BTreeSetInput
+
+**File:** `components/params/inputs/btree-set.tsx`
+
+**Handles:** `BTreeSet<T>`
+
+Unique value set input with duplicate detection.
+
+### Features
+- Add/remove items dynamically
+- Resolves inner element type from chain registry (BTreeSet is a `Sequence` in SCALE)
+- Duplicate detection with validation warning
+- Each item uses the appropriate typed input component
+
+### Props
+Extended interface:
+```typescript
+interface BTreeSetProps extends ParamInputProps {
+  typeId: number;
+}
+```
+
+### Value Type
+`unknown[]` - Array of unique values
+
+### Example Usage
+```tsx
+<BTreeSet
+  client={client}
+  name="members"
+  label="Members"
+  typeId={typeId}
+  onChange={(items) => console.log(items)}
+/>
 ```
 
 ---

--- a/docs/medium-article.md
+++ b/docs/medium-article.md
@@ -112,17 +112,33 @@ Using Relaycode is straightforward:
 
 For your first transaction, try a simple remark (`System.remark`) with some text. It's a free extrinsic that won't transfer any funds—perfect for testing.
 
+### Multi-Chain Support
+
+Relaycode supports multiple chains out of the box. Use the chain selector dropdown in the navbar to switch between **Polkadot**, **Kusama**, and **Westend** (testnet). The builder automatically reconnects, loads the chain's metadata, and adjusts denominations and SS58 prefixes.
+
+### Type Badges
+
+Each parameter field in the builder now shows its Substrate type name (e.g., `MultiAddress`, `Compact<Balance>`) as a badge next to the field label, helping developers understand the underlying types.
+
+### Comprehensive Type Coverage
+
+Beyond the standard types, Relaycode now supports:
+- **BTreeMap<K, V>** - Key-value pair maps with typed inputs
+- **BTreeSet<T>** - Unique value sets with duplicate detection
+- **[T; N]** - Fixed-length arrays
+- **H160, H256, H512** - All hash sizes with correct length validation
+
 ## What's Next
 
 Relaycode is actively developed, with exciting features on the roadmap:
-
-**Multi-Chain Support**: Easily switch between Polkadot, Kusama, parachains, and testnets from a single interface.
 
 **Extrinsic Templates**: Save frequently-used extrinsics as templates. Share them with your team or the community.
 
 **Batch Builder**: Visual interface for constructing complex batch transactions with drag-and-drop ordering.
 
 **Historical Analysis**: Decode and analyze historical extrinsics from block explorers.
+
+**Parachain Support**: Expand beyond relay chains to support Asset Hub, People, Coretime, and custom parachains.
 
 We're building the tools we wish we had when we started developing on Polkadot. If you have ideas for features that would help your workflow, we'd love to hear them.
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -83,8 +83,10 @@ __tests__/
 │   ├── denominations.test.ts
 │   ├── parser.test.ts
 │   └── validation.test.ts
-└── input-map.test.ts
+└── input-map.test.ts          # 52 tests covering all type registrations
 ```
+
+**Current test count:** 163 tests across 7 test suites.
 
 ### Naming Conventions
 
@@ -454,6 +456,34 @@ Then open Chrome DevTools at `chrome://inspect`.
 4. **Use descriptive names** - Test names should explain expected behavior
 5. **Keep tests focused** - One assertion per test when possible
 6. **Clean up** - Reset mocks and state between tests
+
+## Manual Testnet Verification
+
+Follow these steps to verify the builder works end-to-end on a testnet:
+
+### Setup
+1. Install a Polkadot wallet extension (Talisman, Polkadot.js, or SubWallet)
+2. Create or import a testnet account
+3. Get testnet tokens from the Westend faucet
+
+### Verification Steps
+
+1. **Chain Selector**: Use the chain dropdown in the navbar to switch to **Westend** (testnet badge visible)
+2. **Wallet Connect**: Click "Connect" and approve the connection in your wallet
+3. **Metadata Load**: After connecting, verify the builder shows pallets in the Section dropdown
+4. **Build Extrinsic**: Select `System` > `remark` and enter a bytes value (e.g., `0x1234`)
+5. **Type Badges**: Verify the type badge (e.g., `Bytes`) appears next to the field label
+6. **Encode**: Confirm the hex pane updates with the encoded call data
+7. **Decode**: Copy the hex, clear the form, paste it back — verify the form repopulates
+8. **Balance Transfer**: Select `Balances` > `transferKeepAlive`
+   - Verify `dest` shows Account input with type badge `MultiAddress`
+   - Verify `value` shows Balance input with denomination selector and type badge `Compact<Balance>`
+9. **Submit** (optional): Sign and submit the remark extrinsic, verify transaction success toast
+
+### Verifying New Components
+- **BTreeMap**: Find a pallet/method that uses BTreeMap (or verify via input-map tests)
+- **VectorFixed**: Verify `[u8; 32]` pattern matches in input-map tests
+- **Hash variants**: Verify H160 and H512 resolve to correct components in tests
 
 ## See Also
 

--- a/docs/tutorial/advanced.md
+++ b/docs/tutorial/advanced.md
@@ -187,6 +187,48 @@ Vec<Vec<AccountId>>
      └─ [1] 5GNJqTPy...
 ```
 
+## Fixed-Length Arrays
+
+Fixed-length arrays like `[u8; 32]` render a fixed number of input fields:
+
+```
+[u8; 32] — 32 elements
+├── [0]: [u8 input]
+├── [1]: [u8 input]
+├── ...
+└── [31]: [u8 input]
+```
+
+Unlike `Vec<T>`, you cannot add or remove elements. The count is determined by the type definition.
+
+## BTreeMap and BTreeSet
+
+### BTreeMap<K, V>
+
+Key-value maps render as a list of entries, each with typed key and value inputs:
+
+```
+BTreeMap<AccountId, Balance>
+├── Entry 0:  Key: [Account input]  Value: [Balance input]
+├── Entry 1:  Key: [Account input]  Value: [Balance input]
+└── [+ Add Entry]
+```
+
+In the SCALE metadata, BTreeMap is encoded as a `Sequence` of `Tuple`s — Relaycode resolves the key and value types automatically from the chain registry.
+
+### BTreeSet<T>
+
+Sets render similarly to vectors but with duplicate detection:
+
+```
+BTreeSet<AccountId>
+├── Item 0: [Account input]
+├── Item 1: [Account input]
+└── [+ Add Item]
+
+⚠ Set contains duplicate values  ← shown when duplicates detected
+```
+
 ## Option Types
 
 Optional values can be present or absent.

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -16,13 +16,24 @@ Relaycode is an extrinsic builder for the Polkadot ecosystem. It provides a user
 - A Polkadot-compatible wallet (Polkadot.js extension, Talisman, SubWallet, etc.)
 - Some DOT or testnet tokens for transaction fees
 
+## Selecting a Chain
+
+Before connecting, choose which chain to interact with using the **Chain Selector** dropdown in the navbar:
+
+- **Polkadot** - Mainnet (real DOT)
+- **Kusama** - Canary network (real KSM)
+- **Westend** - Testnet (free test tokens, marked with "testnet" badge)
+
+For your first time, we recommend selecting **Westend** so you can experiment without spending real tokens.
+
 ## Connecting Your Wallet
 
 1. **Open Relaycode** and navigate to the Builder page
-2. **Click "Connect Wallet"** in the top navigation
-3. **Select your wallet** from the available options
-4. **Approve the connection** in your wallet extension
-5. Your connected accounts will appear in the Account selector
+2. **Select your chain** from the chain selector dropdown
+3. **Click "Connect"** in the top navigation
+4. **Select your wallet** from the available options (Polkadot.js, Talisman, or SubWallet)
+5. **Approve the connection** in your wallet extension
+6. Your connected accounts will appear in the Account selector
 
 Once connected, you'll see your account balance and be able to select accounts for transactions.
 
@@ -126,14 +137,24 @@ For true/false values:
 - Toggle switch
 
 ### Hash Input
-For block hashes, extrinsic hashes (H256):
-- 32-byte hex input
-- Format validation
+For block hashes, extrinsic hashes:
+- H160 (20-byte), H256 (32-byte), H512 (64-byte)
+- Format and length validation
 
 ### Vector Input
 For arrays (Vec<T>):
 - Add/remove items
 - Dynamic length
+
+### Fixed Array Input
+For fixed-length arrays (`[T; N]`):
+- Fixed number of elements — no add/remove
+- Each element uses the appropriate typed input
+
+### BTreeMap Input
+For key-value maps (BTreeMap<K, V>):
+- Add/remove key-value pairs
+- Typed inputs for keys and values
 
 ### Option Input
 For optional values (Option<T>):


### PR DESCRIPTION
## Summary
- Update input-map API docs with new component registrations (BTreeMap, BTreeSet, VectorFixed, H160/H512)
- Expand input component documentation with usage examples
- Document hex pane decomposition and smart bytes features
- Update medium article draft, testing guide, and tutorials

## Test plan
- [ ] Verify docs render correctly (markdown syntax)
- [ ] No code changes — docs only