### PR TITLE
Enhance all input components with improved UX and encoding fixes

### DIFF
--- a/__tests__/input-map.test.ts
+++ b/__tests__/input-map.test.ts
@@ -252,8 +252,11 @@ describe("findComponent", () => {
   });
 
   describe("Vote type (Priority 60)", () => {
-    it("should return Vote for Vote", () => {
-      expect(findComponent("Vote").component).toBe(Vote);
+    it("should return Vote for AccountVote", () => {
+      expect(findComponent("AccountVote").component).toBe(Vote);
+    });
+    it("should return Vote for AccountVote<BalanceOf<T, I>>", () => {
+      expect(findComponent("AccountVote<BalanceOf<T, I>>").component).toBe(Vote);
     });
   });
 

--- a/components/params/inputs/account-combobox.tsx
+++ b/components/params/inputs/account-combobox.tsx
@@ -51,6 +51,7 @@ export function AccountCombobox({
 }: AccountComboboxProps) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const [pasteConfirmed, setPasteConfirmed] = useState(false);
 
   // Format value for display
   const displayValue = useMemo(() => {
@@ -108,6 +109,23 @@ export function AccountCombobox({
     setSearch("");
   };
 
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const pasted = e.clipboardData.getData("text");
+    // Strip surrounding quotes and whitespace
+    const cleaned = pasted.trim().replace(/^["']|["']$/g, "").trim();
+    if (cleaned && isValidAddress(cleaned)) {
+      e.preventDefault();
+      const formatted = formatAddress(cleaned);
+      if (formatted) {
+        onChange(formatted);
+        setOpen(false);
+        setSearch("");
+        setPasteConfirmed(true);
+        setTimeout(() => setPasteConfirmed(false), 2000);
+      }
+    }
+  };
+
   // Find name for currently selected value
   const selectedAccount = formattedAccounts.find(
     (a) => a.formattedAddress === displayValue
@@ -131,6 +149,9 @@ export function AccountCombobox({
                   ? `${selectedAccount.name} (${truncateAddress(displayValue)})`
                   : truncateAddress(displayValue)}
               </span>
+              {pasteConfirmed && (
+                <Check className="h-4 w-4 text-green-500 shrink-0" />
+              )}
             </div>
           ) : (
             <span className="text-muted-foreground font-normal">
@@ -146,6 +167,7 @@ export function AccountCombobox({
             placeholder="Search or paste address..."
             value={search}
             onValueChange={setSearch}
+            onPaste={handlePaste}
           />
           <CommandList>
             {formattedAccounts.length === 0 &&

--- a/components/params/inputs/amount.tsx
+++ b/components/params/inputs/amount.tsx
@@ -15,6 +15,8 @@ import {
 } from "@/components/ui/select";
 import { useChainToken } from "@/hooks/use-chain-token";
 import { toPlanck, fromPlanck, type Denomination } from "@/lib/denominations";
+import { ModeToggle } from "@/components/params/shared/mode-toggle";
+import { stripNumericFormatting } from "@/lib/paste-utils";
 import type { ParamInputProps } from "../types";
 
 const schema = z.number().min(0);
@@ -25,8 +27,47 @@ const BALANCE_LIKE_TYPES = new Set([
   "u128",
 ]);
 
+/** Types that should get a hex toggle (large integers) */
+const HEX_TOGGLE_TYPES = new Set(["u128", "u256", "i128", "i256", "Compact<u128>"]);
+
 interface AmountProps extends ParamInputProps {
   typeName?: string;
+}
+
+/** Compute min/max range for integer types */
+function getIntegerRange(typeName: string): { min: bigint; max: bigint; display: string } | null {
+  const unsigned: Record<string, number> = {
+    u8: 8, u16: 16, u32: 32, u64: 64, u128: 128, u256: 256,
+  };
+  const signed: Record<string, number> = {
+    i8: 8, i16: 16, i32: 32, i64: 64, i128: 128, i256: 256,
+  };
+
+  // Strip Compact<> wrapper
+  const stripped = typeName.replace(/^Compact<(.+)>$/, "$1");
+
+  if (unsigned[stripped]) {
+    const bits = unsigned[stripped];
+    const max = (BigInt(1) << BigInt(bits)) - BigInt(1);
+    return {
+      min: BigInt(0),
+      max,
+      display: `0 \u2014 ${bits <= 64 ? max.toString() : `2^${bits} - 1`}`,
+    };
+  }
+
+  if (signed[stripped]) {
+    const bits = signed[stripped];
+    const min = -(BigInt(1) << BigInt(bits - 1));
+    const max = (BigInt(1) << BigInt(bits - 1)) - BigInt(1);
+    return {
+      min,
+      max,
+      display: bits <= 64 ? `${min.toString()} \u2014 ${max.toString()}` : `-(2^${bits - 1}) \u2014 2^${bits - 1} - 1`,
+    };
+  }
+
+  return null;
 }
 
 export function Amount({
@@ -43,6 +84,8 @@ export function Amount({
 }: AmountProps) {
   const isDenominated =
     typeName !== undefined && BALANCE_LIKE_TYPES.has(typeName);
+  const showHexToggle =
+    typeName !== undefined && HEX_TOGGLE_TYPES.has(typeName);
 
   // Always call hooks (React rules), but only use results when denominated
   const { denominations, loading } = useChainToken(
@@ -52,6 +95,12 @@ export function Amount({
   const [displayValue, setDisplayValue] = useState("");
   const [selectedDenomLabel, setSelectedDenomLabel] = useState<string>("");
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [numericMode, setNumericMode] = useState<"decimal" | "hex">("decimal");
+
+  const range = useMemo(() => {
+    if (!typeName) return null;
+    return getIntegerRange(typeName);
+  }, [typeName]);
 
   const selectedDenom: Denomination | null = useMemo(() => {
     if (!isDenominated || denominations.length === 0) return null;
@@ -83,11 +132,31 @@ export function Amount({
         // Plain numeric mode
         const numStr = String(externalValue);
         if (displayValue !== numStr) {
-          setDisplayValue(numStr);
+          if (numericMode === "hex") {
+            try {
+              setDisplayValue("0x" + BigInt(numStr).toString(16));
+            } catch {
+              setDisplayValue(numStr);
+            }
+          } else {
+            setDisplayValue(numStr);
+          }
         }
       }
     }
   }, [externalValue, selectedDenom, isDenominated]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Validate range
+  const validateRange = useCallback(
+    (value: bigint | number): string | null => {
+      if (!range) return null;
+      const bigVal = typeof value === "number" ? BigInt(Math.trunc(value)) : value;
+      if (bigVal < range.min) return `Value below minimum (${range.min.toString()})`;
+      if (bigVal > range.max) return `Value above maximum`;
+      return null;
+    },
+    [range]
+  );
 
   // Denominated change handler
   const handleDenominatedChange = useCallback(
@@ -113,11 +182,12 @@ export function Amount({
         setValidationError("Invalid value or excess precision");
         onChange?.(undefined);
       } else {
-        setValidationError(null);
+        const rangeErr = validateRange(BigInt(planck));
+        setValidationError(rangeErr);
         onChange?.(planck);
       }
     },
-    [selectedDenom, onChange]
+    [selectedDenom, onChange, validateRange]
   );
 
   const handleDenomSwitch = useCallback(
@@ -139,9 +209,87 @@ export function Amount({
   );
 
   // Plain number change handler
-  const handlePlainChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value === "" ? undefined : Number(e.target.value);
-    onChange?.(value);
+  const handlePlainChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = e.target.value;
+      setDisplayValue(raw);
+
+      if (!raw.trim()) {
+        setValidationError(null);
+        onChange?.(undefined);
+        return;
+      }
+
+      if (numericMode === "hex") {
+        // Parse hex input
+        try {
+          const val = BigInt(raw);
+          const rangeErr = validateRange(val);
+          setValidationError(rangeErr);
+          onChange?.(val.toString());
+        } catch {
+          setValidationError("Invalid hex value");
+          onChange?.(undefined);
+        }
+      } else {
+        const num = Number(raw);
+        if (isNaN(num)) {
+          setValidationError("Invalid number");
+          onChange?.(undefined);
+          return;
+        }
+        const rangeErr = validateRange(num);
+        setValidationError(rangeErr);
+        // Always emit as string so coerceValue can convert to BigInt for codec
+        try {
+          onChange?.(BigInt(raw).toString());
+        } catch {
+          onChange?.(num.toString());
+        }
+      }
+    },
+    [numericMode, onChange, validateRange, showHexToggle]
+  );
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLInputElement>) => {
+      const pasted = e.clipboardData.getData("text");
+      const stripped = stripNumericFormatting(pasted);
+      if (stripped.transformed) {
+        e.preventDefault();
+        setDisplayValue(stripped.value);
+        // Trigger change with stripped value
+        const syntheticEvent = {
+          target: { value: stripped.value },
+        } as React.ChangeEvent<HTMLInputElement>;
+        if (isDenominated) {
+          handleDenominatedChange(syntheticEvent);
+        } else {
+          handlePlainChange(syntheticEvent);
+        }
+      }
+    },
+    [isDenominated, handleDenominatedChange, handlePlainChange]
+  );
+
+  const handleNumericModeChange = (mode: string) => {
+    const m = mode as "decimal" | "hex";
+    if (m === "hex" && displayValue.trim()) {
+      try {
+        const val = BigInt(displayValue);
+        setDisplayValue("0x" + val.toString(16));
+      } catch {
+        // keep as-is
+      }
+    } else if (m === "decimal" && displayValue.trim()) {
+      try {
+        const val = BigInt(displayValue);
+        setDisplayValue(val.toString());
+      } catch {
+        // keep as-is
+      }
+    }
+    setNumericMode(m);
   };
 
   // Denominated mode
@@ -177,10 +325,16 @@ export function Amount({
           disabled={isDisabled || loading}
           value={displayValue}
           onChange={handleDenominatedChange}
+          onPaste={handlePaste}
           className="font-mono"
           placeholder={isPlanck ? "0" : "0.00"}
           suffix={denomSelector}
         />
+        {range && (
+          <span className="text-xs text-muted-foreground">
+            Range: {range.display}
+          </span>
+        )}
         {description && <FormDescription>{description}</FormDescription>}
         {displayError && (
           <p className="text-sm text-red-500">{displayError}</p>
@@ -190,24 +344,45 @@ export function Amount({
   }
 
   // Plain numeric mode
+  const displayError = validationError || error;
+
   return (
     <div className="flex flex-col gap-2">
-      <Label htmlFor={name}>
-        {label}
-        {isRequired && <span className="text-red-500 ml-1">*</span>}
-      </Label>
+      <div className="flex items-center justify-between">
+        <Label htmlFor={name}>
+          {label}
+          {isRequired && <span className="text-red-500 ml-1">*</span>}
+        </Label>
+        {showHexToggle && (
+          <ModeToggle
+            modes={[
+              { id: "decimal", label: "Dec" },
+              { id: "hex", label: "Hex" },
+            ]}
+            activeMode={numericMode}
+            onModeChange={handleNumericModeChange}
+            disabled={isDisabled}
+          />
+        )}
+      </div>
       <Input
         id={name}
-        type="number"
+        type="text"
+        inputMode="numeric"
         disabled={isDisabled}
         value={displayValue}
         onChange={handlePlainChange}
+        onPaste={handlePaste}
         className="font-mono"
-        placeholder="0"
-        min={0}
+        placeholder={numericMode === "hex" ? "0x0" : "0"}
       />
+      {range && (
+        <span className="text-xs text-muted-foreground">
+          Range: {range.display}
+        </span>
+      )}
       {description && <FormDescription>{description}</FormDescription>}
-      {error && <p className="text-sm text-red-500">{error}</p>}
+      {displayError && <p className="text-sm text-red-500">{displayError}</p>}
     </div>
   );
 }

--- a/components/params/inputs/btree-map.tsx
+++ b/components/params/inputs/btree-map.tsx
@@ -2,17 +2,22 @@ import React from "react";
 import { z } from "zod";
 import { Label } from "@/components/ui/label";
 import { FormDescription } from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Plus, Trash2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import type { ParamInputProps } from "../types";
 import { findComponent } from "@/lib/input-map";
+import { ModeToggle } from "@/components/params/shared/mode-toggle";
+import { parseJsonBulk } from "@/lib/bulk-parse";
 
 interface BTreeMapProps extends ParamInputProps {
   typeId: number;
 }
 
 const schema = z.array(z.tuple([z.any(), z.any()]));
+
+type MapMode = "form" | "json";
 
 export function BTreeMap({
   name,
@@ -26,6 +31,9 @@ export function BTreeMap({
   typeId,
 }: BTreeMapProps) {
   const [pairs, setPairs] = React.useState<[unknown, unknown][]>([[undefined, undefined]]);
+  const [mode, setMode] = React.useState<MapMode>("form");
+  const [jsonText, setJsonText] = React.useState("");
+  const [jsonError, setJsonError] = React.useState<string | null>(null);
 
   // Resolve key/value types from registry
   const { keyType, valueType } = React.useMemo(() => {
@@ -90,6 +98,52 @@ export function BTreeMap({
     emitChange(newPairs);
   };
 
+  const handleModeChange = (newMode: string) => {
+    const m = newMode as MapMode;
+    if (m === "json") {
+      // Pre-populate from current pairs
+      const defined = pairs.filter(([k, v]) => k !== undefined && v !== undefined);
+      if (defined.length > 0) {
+        try {
+          const obj = Object.fromEntries(defined.map(([k, v]) => [String(k), v]));
+          setJsonText(JSON.stringify(obj, null, 2));
+        } catch {
+          setJsonText(JSON.stringify(defined, null, 2));
+        }
+      }
+    } else if (m === "form" && jsonText.trim()) {
+      // Parse JSON back to pairs
+      const result = parseJsonBulk(jsonText, true);
+      if (result.success && result.count > 0) {
+        const newPairs = result.values as [unknown, unknown][];
+        setPairs(newPairs);
+        emitChange(newPairs);
+      }
+      setJsonError(null);
+    }
+    setMode(m);
+  };
+
+  const handleJsonTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const text = e.target.value;
+    setJsonText(text);
+
+    if (!text.trim()) {
+      setJsonError(null);
+      return;
+    }
+
+    const result = parseJsonBulk(text, true);
+    if (result.success) {
+      setJsonError(null);
+      const newPairs = result.values as [unknown, unknown][];
+      setPairs(newPairs);
+      emitChange(newPairs);
+    } else {
+      setJsonError(result.error || "Invalid JSON");
+    }
+  };
+
   const keyResolved = keyType ? findComponent(keyType.typeName, keyType.typeId) : null;
   const valueResolved = valueType ? findComponent(valueType.typeName, valueType.typeId) : null;
 
@@ -100,74 +154,100 @@ export function BTreeMap({
           {label}
           {isRequired && <span className="text-red-500 ml-1">*</span>}
         </Label>
-        {!isDisabled && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleAdd}
-            className="flex items-center gap-1"
-          >
-            <Plus className="h-4 w-4" />
-            Add Entry
-          </Button>
-        )}
+        <div className="flex items-center gap-2">
+          <ModeToggle
+            modes={[
+              { id: "form", label: "Form" },
+              { id: "json", label: "JSON" },
+            ]}
+            activeMode={mode}
+            onModeChange={handleModeChange}
+            disabled={isDisabled}
+          />
+          {mode === "form" && !isDisabled && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleAdd}
+              className="flex items-center gap-1"
+            >
+              <Plus className="h-4 w-4" />
+              Add Entry
+            </Button>
+          )}
+        </div>
       </div>
-      <div className="flex flex-col gap-2">
-        {pairs.map((_, index) => (
-          <Card key={index}>
-            <CardContent className="pt-4 pb-3 space-y-3">
-              <div className="flex items-start gap-2">
-                <div className="flex-1 space-y-3">
-                  {keyResolved ? (
-                    <keyResolved.component
-                      client={client}
-                      name={`${name}-key-${index}`}
-                      label="Key"
-                      typeId={keyType!.typeId}
-                      isDisabled={isDisabled}
-                      onChange={(v: unknown) => handleKeyChange(index, v)}
-                    />
-                  ) : (
-                    <input
-                      className="w-full rounded border px-2 py-1 text-sm font-mono"
-                      placeholder="Key"
-                      disabled={isDisabled}
-                      onChange={(e) => handleKeyChange(index, e.target.value)}
-                    />
-                  )}
-                  {valueResolved ? (
-                    <valueResolved.component
-                      client={client}
-                      name={`${name}-val-${index}`}
-                      label="Value"
-                      typeId={valueType!.typeId}
-                      isDisabled={isDisabled}
-                      onChange={(v: unknown) => handleValueChange(index, v)}
-                    />
-                  ) : (
-                    <input
-                      className="w-full rounded border px-2 py-1 text-sm font-mono"
-                      placeholder="Value"
-                      disabled={isDisabled}
-                      onChange={(e) => handleValueChange(index, e.target.value)}
-                    />
+
+      {mode === "form" ? (
+        <div className="flex flex-col gap-2">
+          {pairs.map((_, index) => (
+            <Card key={index}>
+              <CardContent className="pt-4 pb-3 space-y-3">
+                <div className="flex items-start gap-2">
+                  <div className="flex-1 space-y-3">
+                    {keyResolved ? (
+                      <keyResolved.component
+                        client={client}
+                        name={`${name}-key-${index}`}
+                        label="Key"
+                        typeId={keyType!.typeId}
+                        isDisabled={isDisabled}
+                        onChange={(v: unknown) => handleKeyChange(index, v)}
+                      />
+                    ) : (
+                      <input
+                        className="w-full rounded border px-2 py-1 text-sm font-mono"
+                        placeholder="Key"
+                        disabled={isDisabled}
+                        onChange={(e) => handleKeyChange(index, e.target.value)}
+                      />
+                    )}
+                    {valueResolved ? (
+                      <valueResolved.component
+                        client={client}
+                        name={`${name}-val-${index}`}
+                        label="Value"
+                        typeId={valueType!.typeId}
+                        isDisabled={isDisabled}
+                        onChange={(v: unknown) => handleValueChange(index, v)}
+                      />
+                    ) : (
+                      <input
+                        className="w-full rounded border px-2 py-1 text-sm font-mono"
+                        placeholder="Value"
+                        disabled={isDisabled}
+                        onChange={(e) => handleValueChange(index, e.target.value)}
+                      />
+                    )}
+                  </div>
+                  {!isDisabled && pairs.length > 1 && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleRemove(index)}
+                      className="mt-1"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
                   )}
                 </div>
-                {!isDisabled && pairs.length > 1 && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => handleRemove(index)}
-                    className="mt-1"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                )}
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <Textarea
+          disabled={isDisabled}
+          value={jsonText}
+          onChange={handleJsonTextChange}
+          className={`font-mono min-h-[120px] ${jsonError ? "border-red-500" : ""}`}
+          placeholder={'{"key1": "value1", "key2": "value2"}\nor\n[["key1", "value1"], ["key2", "value2"]]'}
+        />
+      )}
+
+      {jsonError && mode === "json" && (
+        <p className="text-sm text-red-500">{jsonError}</p>
+      )}
       {description && <FormDescription>{description}</FormDescription>}
       {error && <p className="text-sm text-red-500">{error}</p>}
     </div>

--- a/components/params/inputs/btree-set.tsx
+++ b/components/params/inputs/btree-set.tsx
@@ -2,16 +2,21 @@ import React from "react";
 import { z } from "zod";
 import { Label } from "@/components/ui/label";
 import { FormDescription } from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Plus, Trash2 } from "lucide-react";
 import type { ParamInputProps } from "../types";
 import { findComponent } from "@/lib/input-map";
+import { ModeToggle } from "@/components/params/shared/mode-toggle";
+import { parseJsonBulk } from "@/lib/bulk-parse";
 
 interface BTreeSetProps extends ParamInputProps {
   typeId: number;
 }
 
 const schema = z.array(z.any());
+
+type SetMode = "form" | "json";
 
 export function BTreeSet({
   name,
@@ -26,6 +31,9 @@ export function BTreeSet({
 }: BTreeSetProps) {
   const [items, setItems] = React.useState<unknown[]>([undefined]);
   const [validationError, setValidationError] = React.useState<string | null>(null);
+  const [mode, setMode] = React.useState<SetMode>("form");
+  const [jsonText, setJsonText] = React.useState("");
+  const [jsonError, setJsonError] = React.useState<string | null>(null);
 
   // Resolve inner type from registry
   const innerType = React.useMemo(() => {
@@ -79,8 +87,47 @@ export function BTreeSet({
     emitChange(newItems);
   };
 
+  const handleModeChange = (newMode: string) => {
+    const m = newMode as SetMode;
+    if (m === "json") {
+      // Pre-populate from current items
+      const defined = items.filter((item) => item !== undefined);
+      if (defined.length > 0) {
+        setJsonText(JSON.stringify(defined, null, 2));
+      }
+    } else if (m === "form" && jsonText.trim()) {
+      // Parse JSON back to items
+      const result = parseJsonBulk(jsonText);
+      if (result.success && result.count > 0) {
+        setItems(result.values);
+        emitChange(result.values);
+      }
+      setJsonError(null);
+    }
+    setMode(m);
+  };
+
+  const handleJsonTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const text = e.target.value;
+    setJsonText(text);
+
+    if (!text.trim()) {
+      setJsonError(null);
+      return;
+    }
+
+    const result = parseJsonBulk(text);
+    if (result.success) {
+      setJsonError(null);
+      setItems(result.values);
+      emitChange(result.values);
+    } else {
+      setJsonError(result.error || "Invalid JSON");
+    }
+  };
+
   const resolved = innerType ? findComponent(innerType.typeName, innerType.typeId) : null;
-  const displayError = validationError || error;
+  const displayError = validationError || error || (mode === "json" ? jsonError : null);
 
   return (
     <div className="flex flex-col gap-2">
@@ -89,53 +136,76 @@ export function BTreeSet({
           {label}
           {isRequired && <span className="text-red-500 ml-1">*</span>}
         </Label>
-        {!isDisabled && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleAdd}
-            className="flex items-center gap-1"
-          >
-            <Plus className="h-4 w-4" />
-            Add Item
-          </Button>
-        )}
+        <div className="flex items-center gap-2">
+          <ModeToggle
+            modes={[
+              { id: "form", label: "Form" },
+              { id: "json", label: "JSON" },
+            ]}
+            activeMode={mode}
+            onModeChange={handleModeChange}
+            disabled={isDisabled}
+          />
+          {mode === "form" && !isDisabled && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleAdd}
+              className="flex items-center gap-1"
+            >
+              <Plus className="h-4 w-4" />
+              Add Item
+            </Button>
+          )}
+        </div>
       </div>
-      <div className="flex flex-col gap-2">
-        {items.map((_, index) => (
-          <div key={index} className="flex items-start gap-2">
-            <div className="flex-1">
-              {resolved ? (
-                <resolved.component
-                  client={client}
-                  name={`${name}-${index}`}
-                  label={`Item ${index}`}
-                  typeId={innerType!.typeId}
-                  isDisabled={isDisabled}
-                  onChange={(v: unknown) => handleItemChange(index, v)}
-                />
-              ) : (
-                <input
-                  className="w-full rounded border px-2 py-1 text-sm font-mono"
-                  placeholder={`Item ${index}`}
-                  disabled={isDisabled}
-                  onChange={(e) => handleItemChange(index, e.target.value)}
-                />
+
+      {mode === "form" ? (
+        <div className="flex flex-col gap-2">
+          {items.map((_, index) => (
+            <div key={index} className="flex items-start gap-2">
+              <div className="flex-1">
+                {resolved ? (
+                  <resolved.component
+                    client={client}
+                    name={`${name}-${index}`}
+                    label={`Item ${index}`}
+                    typeId={innerType!.typeId}
+                    isDisabled={isDisabled}
+                    onChange={(v: unknown) => handleItemChange(index, v)}
+                  />
+                ) : (
+                  <input
+                    className="w-full rounded border px-2 py-1 text-sm font-mono"
+                    placeholder={`Item ${index}`}
+                    disabled={isDisabled}
+                    onChange={(e) => handleItemChange(index, e.target.value)}
+                  />
+                )}
+              </div>
+              {!isDisabled && items.length > 1 && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleRemove(index)}
+                  className="mt-1"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
               )}
             </div>
-            {!isDisabled && items.length > 1 && (
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => handleRemove(index)}
-                className="mt-1"
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
-            )}
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      ) : (
+        <Textarea
+          disabled={isDisabled}
+          value={jsonText}
+          onChange={handleJsonTextChange}
+          className={`font-mono min-h-[120px] ${jsonError ? "border-red-500" : ""}`}
+          placeholder={'["value1", "value2", "value3"]'}
+        />
+      )}
+
       {description && <FormDescription>{description}</FormDescription>}
       {displayError && <p className="text-sm text-red-500">{displayError}</p>}
     </div>

--- a/components/params/inputs/bytes.tsx
+++ b/components/params/inputs/bytes.tsx
@@ -8,8 +8,16 @@ import { Button } from "@/components/ui/button";
 import type { ParamInputProps } from "../types";
 import { isHex } from "dedot/utils";
 import { Upload } from "lucide-react";
+import { ModeToggle } from "@/components/params/shared/mode-toggle";
+import {
+  bytesToHex,
+  hexToBytes,
+  tryDecodeUtf8,
+  base64ToBytes,
+  bytesToBase64,
+} from "@/lib/byte-utils";
 
-type InputMode = "hex" | "text" | "file";
+type InputMode = "hex" | "text" | "json" | "file" | "base64";
 
 const schema = z.string().refine((value) => {
   if (value === "") return true;
@@ -17,36 +25,6 @@ const schema = z.string().refine((value) => {
 }, {
   message: "Invalid bytes (must be hex string with 0x prefix and even length)",
 });
-
-function bytesToHex(bytes: Uint8Array): string {
-  if (bytes.length === 0) return "";
-  return "0x" + Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
-}
-
-function hexToBytes(hex: string): Uint8Array | null {
-  const stripped = hex.startsWith("0x") ? hex.slice(2) : hex;
-  if (stripped.length === 0) return new Uint8Array(0);
-  if (stripped.length % 2 !== 0) return null;
-  if (!/^[0-9a-fA-F]+$/.test(stripped)) return null;
-  const bytes = new Uint8Array(stripped.length / 2);
-  for (let i = 0; i < stripped.length; i += 2) {
-    bytes[i / 2] = parseInt(stripped.slice(i, i + 2), 16);
-  }
-  return bytes;
-}
-
-function tryDecodeUtf8(hex: string): string | null {
-  const bytes = hexToBytes(hex);
-  if (!bytes || bytes.length === 0) return null;
-  try {
-    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-    // Reject if it contains control characters (except newline/tab) — likely binary
-    if (/[\x00-\x08\x0B\x0C\x0E-\x1F]/.test(text)) return null;
-    return text;
-  } catch {
-    return null;
-  }
-}
 
 export function Bytes({
   name,
@@ -61,6 +39,10 @@ export function Bytes({
   const [mode, setMode] = React.useState<InputMode>("hex");
   const [hexValue, setHexValue] = React.useState("");
   const [textValue, setTextValue] = React.useState("");
+  const [jsonValue, setJsonValue] = React.useState("");
+  const [base64Value, setBase64Value] = React.useState("");
+  const [jsonError, setJsonError] = React.useState<string | null>(null);
+  const [base64Error, setBase64Error] = React.useState<string | null>(null);
   const [fileName, setFileName] = React.useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -74,6 +56,18 @@ export function Bytes({
         const decoded = tryDecodeUtf8(str);
         if (decoded !== null) {
           setTextValue(decoded);
+          // Try to parse as JSON
+          try {
+            JSON.parse(decoded);
+            setJsonValue(decoded);
+          } catch {
+            // not JSON
+          }
+        }
+        // Sync base64
+        const bytes = hexToBytes(str);
+        if (bytes) {
+          setBase64Value(bytesToBase64(bytes));
         }
         setFileName(null);
       }
@@ -85,13 +79,23 @@ export function Bytes({
     onChange?.(hex === "" ? undefined : hex);
   };
 
+  // Sync other displays from hex
+  const syncFromHex = (hex: string) => {
+    const decoded = tryDecodeUtf8(hex);
+    if (decoded !== null) setTextValue(decoded);
+    const bytes = hexToBytes(hex);
+    if (bytes && bytes.length > 0) {
+      setBase64Value(bytesToBase64(bytes));
+    }
+  };
+
   const handleHexChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value.trim().toLowerCase();
     const formatted = val && !val.startsWith("0x") ? `0x${val}` : val;
     setHexValue(formatted);
-    // Sync text display
-    const decoded = tryDecodeUtf8(formatted);
-    if (decoded !== null) setTextValue(decoded);
+    syncFromHex(formatted);
+    setJsonError(null);
+    setBase64Error(null);
     onChange?.(formatted === "" ? undefined : formatted);
   };
 
@@ -99,32 +103,118 @@ export function Bytes({
     const text = e.target.value;
     setTextValue(text);
     setFileName(null);
+    setJsonError(null);
+    setBase64Error(null);
     if (text === "") {
       emitHex("");
       return;
     }
     const encoded = new TextEncoder().encode(text);
-    emitHex(bytesToHex(encoded));
+    const hex = bytesToHex(encoded);
+    setHexValue(hex);
+    const bytes = hexToBytes(hex);
+    if (bytes) setBase64Value(bytesToBase64(bytes));
+    onChange?.(hex === "" ? undefined : hex);
+  };
+
+  const handleJsonChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const raw = e.target.value;
+    setJsonValue(raw);
+    setBase64Error(null);
+
+    if (!raw.trim()) {
+      setJsonError(null);
+      emitHex("");
+      return;
+    }
+
+    try {
+      JSON.parse(raw);
+      setJsonError(null);
+      // Encode the JSON string as UTF-8 bytes → hex
+      const encoded = new TextEncoder().encode(raw);
+      const hex = bytesToHex(encoded);
+      setHexValue(hex);
+      setTextValue(raw);
+      const bytes = hexToBytes(hex);
+      if (bytes) setBase64Value(bytesToBase64(bytes));
+      onChange?.(hex === "" ? undefined : hex);
+    } catch {
+      setJsonError("Invalid JSON");
+    }
+  };
+
+  const handleBase64Change = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value.trim();
+    setBase64Value(raw);
+    setJsonError(null);
+
+    if (!raw) {
+      setBase64Error(null);
+      emitHex("");
+      return;
+    }
+
+    const bytes = base64ToBytes(raw);
+    if (!bytes) {
+      setBase64Error("Invalid Base64 string");
+      return;
+    }
+    setBase64Error(null);
+    const hex = bytesToHex(bytes);
+    setHexValue(hex);
+    const decoded = tryDecodeUtf8(hex);
+    if (decoded !== null) setTextValue(decoded);
+    onChange?.(hex === "" ? undefined : hex);
   };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
     setFileName(file.name);
+    setJsonError(null);
+    setBase64Error(null);
     const reader = new FileReader();
     reader.onload = () => {
       const buffer = reader.result as ArrayBuffer;
       const bytes = new Uint8Array(buffer);
       const hex = bytesToHex(bytes);
       setTextValue("");
+      setBase64Value(bytesToBase64(bytes));
       emitHex(hex);
     };
     reader.readAsArrayBuffer(file);
   };
 
+  const handleModeChange = (newMode: string) => {
+    const m = newMode as InputMode;
+    // When switching to JSON mode, try to pre-populate
+    if (m === "json" && hexValue) {
+      const decoded = tryDecodeUtf8(hexValue);
+      if (decoded !== null) {
+        try {
+          // Validate it's JSON, then pretty-print
+          const parsed = JSON.parse(decoded);
+          setJsonValue(JSON.stringify(parsed, null, 2));
+          setJsonError(null);
+        } catch {
+          setJsonValue(decoded);
+          setJsonError("Current data is not valid JSON");
+        }
+      } else {
+        setJsonValue("");
+        setJsonError("Current data contains non-text bytes");
+      }
+    }
+    setMode(m);
+  };
+
   const byteCount = hexValue && hexValue.startsWith("0x") && hexValue.length > 2
     ? (hexValue.length - 2) / 2
     : 0;
+
+  const modeError = mode === "json" ? jsonError : mode === "base64" ? base64Error : null;
+  const displayError = modeError || error;
 
   return (
     <div className="flex flex-col gap-2">
@@ -133,23 +223,18 @@ export function Bytes({
           {label}
           {isRequired && <span className="text-red-500 ml-1">*</span>}
         </Label>
-        <div className="flex gap-1">
-          {(["hex", "text", "file"] as const).map((m) => (
-            <button
-              key={m}
-              type="button"
-              onClick={() => setMode(m)}
-              disabled={isDisabled}
-              className={`px-2 py-0.5 text-xs rounded-full border transition-colors ${
-                mode === m
-                  ? "bg-primary text-primary-foreground border-primary"
-                  : "bg-background text-muted-foreground border-input hover:bg-accent"
-              }`}
-            >
-              {m === "hex" ? "Hex" : m === "text" ? "Text" : "File"}
-            </button>
-          ))}
-        </div>
+        <ModeToggle
+          modes={[
+            { id: "hex", label: "Hex" },
+            { id: "text", label: "Text" },
+            { id: "json", label: "JSON" },
+            { id: "base64", label: "B64" },
+            { id: "file", label: "File" },
+          ]}
+          activeMode={mode}
+          onModeChange={handleModeChange}
+          disabled={isDisabled}
+        />
       </div>
 
       {mode === "hex" && (
@@ -172,6 +257,29 @@ export function Bytes({
           onChange={handleTextChange}
           className="font-mono min-h-[80px]"
           placeholder="Enter text (auto-converts to hex)"
+        />
+      )}
+
+      {mode === "json" && (
+        <Textarea
+          id={name}
+          disabled={isDisabled}
+          value={jsonValue}
+          onChange={handleJsonChange}
+          className={`font-mono min-h-[80px] ${jsonError ? "border-red-500" : ""}`}
+          placeholder='{"key": "value"}'
+        />
+      )}
+
+      {mode === "base64" && (
+        <Input
+          id={name}
+          type="text"
+          disabled={isDisabled}
+          value={base64Value}
+          onChange={handleBase64Change}
+          className={`font-mono ${base64Error ? "border-red-500" : ""}`}
+          placeholder="SGVsbG8gV29ybGQ="
         />
       )}
 
@@ -211,7 +319,7 @@ export function Bytes({
           </span>
         )}
       </div>
-      {error && <p className="text-sm text-red-500">{error}</p>}
+      {displayError && <p className="text-sm text-red-500">{displayError}</p>}
     </div>
   );
 }

--- a/components/params/inputs/call.tsx
+++ b/components/params/inputs/call.tsx
@@ -185,7 +185,7 @@ export function Call({
                 Parameters
               </label>
               {methodFields.map((field) => {
-                const resolved = findComponent(field.typeName, field.typeId);
+                const resolved = findComponent(field.typeName, field.typeId, client);
                 const Component = resolved.component;
                 return (
                   <div key={field.name} className="ml-4">
@@ -195,6 +195,7 @@ export function Call({
                       label={field.name}
                       description={field.typeName}
                       typeId={field.typeId}
+                      typeName={field.typeName}
                       isDisabled={isDisabled}
                       onChange={(value: unknown) => handleArgChange(field.name, value)}
                     />

--- a/components/params/inputs/key-value.tsx
+++ b/components/params/inputs/key-value.tsx
@@ -5,6 +5,7 @@ import { FormDescription } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 import type { ParamInputProps } from "../types";
+import { findComponent } from "@/lib/input-map";
 
 interface KeyValueProps extends ParamInputProps {
   keyComponent?: React.ReactNode;
@@ -24,11 +25,38 @@ export function KeyValue({
   isRequired,
   error,
   onChange,
+  client,
+  typeId,
   keyComponent,
   valueComponent,
 }: KeyValueProps) {
   const [keyValue, setKeyValue] = React.useState<any>();
   const [valueValue, setValueValue] = React.useState<any>();
+
+  // Try to resolve key/value types from metadata when no explicit components
+  const resolvedTypes = React.useMemo(() => {
+    if (keyComponent || valueComponent) return null;
+    if (!client || typeId === undefined) return null;
+
+    try {
+      const typeInfo = client.registry.findType(typeId);
+      if (typeInfo.typeDef.type === "Tuple" && typeInfo.typeDef.value.fields.length === 2) {
+        const keyTypeId = typeInfo.typeDef.value.fields[0];
+        const valTypeId = typeInfo.typeDef.value.fields[1];
+        const keyTypeInfo = client.registry.findType(keyTypeId);
+        const valTypeInfo = client.registry.findType(valTypeId);
+        const keyTypeName = keyTypeInfo.path?.join("::") || keyTypeInfo.typeDef.type || "";
+        const valTypeName = valTypeInfo.path?.join("::") || valTypeInfo.typeDef.type || "";
+        return {
+          key: { typeId: keyTypeId, typeName: keyTypeName, resolved: findComponent(keyTypeName, keyTypeId, client) },
+          value: { typeId: valTypeId, typeName: valTypeName, resolved: findComponent(valTypeName, valTypeId, client) },
+        };
+      }
+    } catch {
+      // Type resolution failed
+    }
+    return null;
+  }, [client, typeId, keyComponent, valueComponent]);
 
   const handleKeyChange = (value: any) => {
     setKeyValue(value);
@@ -60,6 +88,23 @@ export function KeyValue({
       });
     }
 
+    // Use resolved typed component if available
+    if (resolvedTypes?.key) {
+      const KeyComp = resolvedTypes.key.resolved.component;
+      return (
+        <KeyComp
+          client={client}
+          name={`${name}-key`}
+          label="Key"
+          typeId={resolvedTypes.key.typeId}
+          typeName={resolvedTypes.key.typeName}
+          isDisabled={isDisabled}
+          isRequired={isRequired}
+          onChange={handleKeyChange}
+        />
+      );
+    }
+
     // Default to text input if no component provided
     return (
       <div className="flex flex-col gap-2">
@@ -85,6 +130,23 @@ export function KeyValue({
         isRequired: isRequired,
         onChange: handleValueChange,
       });
+    }
+
+    // Use resolved typed component if available
+    if (resolvedTypes?.value) {
+      const ValComp = resolvedTypes.value.resolved.component;
+      return (
+        <ValComp
+          client={client}
+          name={`${name}-value`}
+          label="Value"
+          typeId={resolvedTypes.value.typeId}
+          typeName={resolvedTypes.value.typeName}
+          isDisabled={isDisabled}
+          isRequired={isRequired}
+          onChange={handleValueChange}
+        />
+      );
     }
 
     // Default to text input if no component provided

--- a/components/params/inputs/moment.tsx
+++ b/components/params/inputs/moment.tsx
@@ -3,9 +3,29 @@ import { z } from "zod";
 import { Label } from "@/components/ui/label";
 import { FormDescription } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 import type { ParamInputProps } from "../types";
 
 const schema = z.number().int().min(0);
+
+function toDatetimeLocal(ms: number): string {
+  const d = new Date(ms);
+  // Format: YYYY-MM-DDTHH:mm
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const hours = String(d.getHours()).padStart(2, "0");
+  const minutes = String(d.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+const PRESETS = [
+  { label: "Now", offset: 0 },
+  { label: "+1h", offset: 60 * 60 * 1000 },
+  { label: "+6h", offset: 6 * 60 * 60 * 1000 },
+  { label: "+24h", offset: 24 * 60 * 60 * 1000 },
+  { label: "+7d", offset: 7 * 24 * 60 * 60 * 1000 },
+];
 
 export function Moment({
   name,
@@ -15,21 +35,45 @@ export function Moment({
   isRequired,
   error,
   onChange,
+  value: externalValue,
 }: ParamInputProps) {
+  const [displayValue, setDisplayValue] = React.useState("");
+  const [timezone] = React.useState(
+    () => Intl.DateTimeFormat().resolvedOptions().timeZone
+  );
+
+  // Sync from external value
+  React.useEffect(() => {
+    if (externalValue !== undefined && externalValue !== null) {
+      const ts = Number(externalValue);
+      if (!isNaN(ts) && ts > 0) {
+        setDisplayValue(toDatetimeLocal(ts));
+      }
+    }
+  }, [externalValue]);
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
+    setDisplayValue(value);
+
     if (value === "") {
       onChange?.(undefined);
       return;
     }
 
-    // Convert date-time to Unix timestamp in milliseconds
+    // Convert date-time to Unix timestamp in milliseconds (as string for BigInt compat)
     try {
       const timestamp = new Date(value).getTime();
-      onChange?.(timestamp);
+      onChange?.(timestamp.toString());
     } catch {
       onChange?.(undefined);
     }
+  };
+
+  const handlePreset = (offset: number) => {
+    const ts = Date.now() + offset;
+    setDisplayValue(toDatetimeLocal(ts));
+    onChange?.(ts.toString());
   };
 
   return (
@@ -42,9 +86,28 @@ export function Moment({
         id={name}
         type="datetime-local"
         disabled={isDisabled}
+        value={displayValue}
         onChange={handleChange}
         className="font-mono"
       />
+      <div className="flex items-center gap-1 flex-wrap">
+        {PRESETS.map((preset) => (
+          <Button
+            key={preset.label}
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs"
+            disabled={isDisabled}
+            onClick={() => handlePreset(preset.offset)}
+          >
+            {preset.label}
+          </Button>
+        ))}
+      </div>
+      <span className="text-xs text-muted-foreground">
+        Timezone: {timezone}
+      </span>
       {description && <FormDescription>{description}</FormDescription>}
       {error && <p className="text-sm text-red-500">{error}</p>}
     </div>

--- a/components/params/inputs/option.tsx
+++ b/components/params/inputs/option.tsx
@@ -3,10 +3,12 @@ import { z } from "zod";
 import { Label } from "@/components/ui/label";
 import { FormDescription } from "@/components/ui/form";
 import { Switch } from "@/components/ui/switch";
+import { AnimatePresence, motion } from "framer-motion";
 import type { ParamInputProps } from "../types";
+import { findComponent } from "@/lib/input-map";
 
 interface OptionProps extends ParamInputProps {
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 const schema = z.any().optional();
@@ -19,9 +21,44 @@ export function Option({
   isRequired,
   error,
   onChange,
+  value: externalValue,
   children,
+  client,
+  typeId,
 }: OptionProps) {
   const [isEnabled, setIsEnabled] = React.useState(false);
+
+  // Resolve the inner type from metadata (Option is Enum with None/Some variants)
+  const innerType = React.useMemo(() => {
+    if (!client || typeId === undefined) return null;
+    try {
+      const typeInfo = client.registry.findType(typeId);
+      const typeDef = typeInfo?.typeDef;
+      // Option in Dedot = Enum with members [None, Some(T)]
+      if (typeDef && typeDef.type === "Enum") {
+        const someVariant = typeDef.value.members?.find(
+          (m: any) => m.name === "Some"
+        );
+        if (someVariant && someVariant.fields?.length === 1) {
+          const innerTypeId = someVariant.fields[0].typeId;
+          const innerTypeInfo = client.registry.findType(innerTypeId);
+          const path = (innerTypeInfo as any)?.path as string[] | undefined;
+          const typeName = path && path.length > 0 ? path[path.length - 1] : "";
+          return { typeId: innerTypeId, typeName };
+        }
+      }
+    } catch {
+      // Type lookup failed
+    }
+    return null;
+  }, [client, typeId]);
+
+  // Sync from external value: if a value is provided, auto-enable
+  React.useEffect(() => {
+    if (externalValue !== undefined && externalValue !== null) {
+      setIsEnabled(true);
+    }
+  }, [externalValue]);
 
   const handleSwitchChange = (checked: boolean) => {
     setIsEnabled(checked);
@@ -36,16 +73,43 @@ export function Option({
     }
   };
 
-  // Clone the child component with modified props
-  const childComponent = React.Children.map(children, (child) => {
-    if (React.isValidElement(child)) {
-      return React.cloneElement(child as React.ReactElement<any>, {
-        isDisabled: !isEnabled || isDisabled,
-        onChange: handleChildChange,
+  // Build the child component: use passed children or self-resolve from metadata
+  const renderedChild = React.useMemo(() => {
+    if (children) {
+      // Legacy: clone provided children
+      return React.Children.map(children, (child) => {
+        if (React.isValidElement(child)) {
+          return React.cloneElement(child as React.ReactElement<any>, {
+            isDisabled: !isEnabled || isDisabled,
+            onChange: handleChildChange,
+            value: externalValue,
+          });
+        }
+        return child;
       });
     }
-    return child;
-  });
+
+    if (innerType) {
+      // Self-resolving: derive inner component from metadata
+      const resolved = findComponent(innerType.typeName, innerType.typeId, client);
+      const InnerComponent = resolved.component;
+      return (
+        <InnerComponent
+          client={client}
+          name={`${name}-value`}
+          label={`${label || name} value`}
+          typeId={innerType.typeId}
+          typeName={innerType.typeName}
+          isDisabled={!isEnabled || isDisabled}
+          value={externalValue}
+          onChange={handleChildChange}
+        />
+      );
+    }
+
+    return null;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [children, innerType, isEnabled, isDisabled, externalValue, client, name, label]);
 
   return (
     <div className="flex flex-col gap-2">
@@ -54,16 +118,31 @@ export function Option({
           {label}
           {isRequired && <span className="text-red-500 ml-1">*</span>}
         </Label>
-        <Switch
-          id={`${name}-switch`}
-          checked={isEnabled}
-          onCheckedChange={handleSwitchChange}
-          disabled={isDisabled}
-        />
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">
+            {isEnabled ? "Some" : "None"}
+          </span>
+          <Switch
+            id={`${name}-switch`}
+            checked={isEnabled}
+            onCheckedChange={handleSwitchChange}
+            disabled={isDisabled}
+          />
+        </div>
       </div>
-      <div className={isEnabled ? "opacity-100" : "opacity-50 pointer-events-none"}>
-        {childComponent}
-      </div>
+      <AnimatePresence initial={false}>
+        {isEnabled && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.2 }}
+            style={{ overflow: "hidden" }}
+          >
+            {renderedChild}
+          </motion.div>
+        )}
+      </AnimatePresence>
       {description && <FormDescription>{description}</FormDescription>}
       {error && <p className="text-sm text-red-500">{error}</p>}
     </div>

--- a/components/params/inputs/struct.tsx
+++ b/components/params/inputs/struct.tsx
@@ -10,6 +10,7 @@ interface StructField {
   name: string;
   label: string;
   description?: string;
+  typeName?: string;
   component: React.ReactNode;
   required?: boolean;
 }
@@ -67,14 +68,25 @@ export function Struct({
       if (React.isValidElement(field.component)) {
         return (
           <div key={field.name} className="mb-4 last:mb-0">
-            {React.cloneElement(field.component as React.ReactElement<any>, {
-              name: `${name}-${field.name}`,
-              label: field.label,
-              description: field.description,
-              isDisabled: isDisabled,
-              isRequired: field.required,
-              onChange: (value: any) => handleFieldChange(field.name, value),
-            })}
+            <div className="flex items-center gap-2 mb-1">
+              {React.cloneElement(field.component as React.ReactElement<any>, {
+                name: `${name}-${field.name}`,
+                label: (
+                  <span className="flex items-center gap-1.5">
+                    {field.label}
+                    {field.typeName && (
+                      <code className="text-[10px] px-1 py-0.5 bg-muted rounded text-muted-foreground font-mono">
+                        {field.typeName}
+                      </code>
+                    )}
+                  </span>
+                ),
+                description: field.description,
+                isDisabled: isDisabled,
+                isRequired: field.required,
+                onChange: (value: any) => handleFieldChange(field.name, value),
+              })}
+            </div>
           </div>
         );
       }

--- a/components/params/inputs/tuple.tsx
+++ b/components/params/inputs/tuple.tsx
@@ -12,6 +12,13 @@ interface TupleProps extends ParamInputProps {
 
 const schema = z.array(z.any());
 
+/** Extract the last segment of a type path for a readable label */
+function shortTypeName(typeName: string): string {
+  // "sp_runtime::multiaddress::MultiAddress" → "MultiAddress"
+  const parts = typeName.split("::");
+  return parts[parts.length - 1] || typeName;
+}
+
 export function Tuple({
   name,
   label,
@@ -92,16 +99,18 @@ export function Tuple({
       <Card>
         <CardContent className="pt-4 space-y-4">
           {tupleFields.map((field) => {
-            const resolved = findComponent(field.typeName, field.typeId);
+            const resolved = findComponent(field.typeName, field.typeId, client);
             const Component = resolved.component;
+            const fieldLabel = `${shortTypeName(field.typeName)} [${field.index}]`;
             return (
               <div key={field.index}>
                 <Component
                   client={client}
                   name={`${name}-${field.index}`}
-                  label={`Element ${field.index}`}
+                  label={fieldLabel}
                   description={field.typeName}
                   typeId={field.typeId}
+                  typeName={field.typeName}
                   isDisabled={isDisabled}
                   onChange={(value: unknown) => handleFieldChange(field.index, value)}
                 />

--- a/components/params/inputs/vector-fixed.tsx
+++ b/components/params/inputs/vector-fixed.tsx
@@ -1,15 +1,25 @@
 import React from "react";
 import { z } from "zod";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { FormDescription } from "@/components/ui/form";
 import type { ParamInputProps } from "../types";
 import { findComponent } from "@/lib/input-map";
+import { ModeToggle } from "@/components/params/shared/mode-toggle";
+import {
+  bytesToHex,
+  hexToBytes,
+  base64ToBytes,
+  bytesToBase64,
+} from "@/lib/byte-utils";
 
 interface VectorFixedProps extends ParamInputProps {
   typeId: number;
 }
 
 const schema = z.array(z.any());
+
+type ByteMode = "hex" | "base64";
 
 export function VectorFixed({
   name,
@@ -19,46 +29,132 @@ export function VectorFixed({
   isRequired,
   error,
   onChange,
+  value: externalValue,
   client,
   typeId,
   typeName,
 }: VectorFixedProps) {
-  // Parse fixed length from typeName like "[u8; 32]"
-  const { length, innerTypeName } = React.useMemo(() => {
+  // Parse fixed length and inner type from typeName like "[u8; 32]"
+  const { length, innerTypeName, isU8Array } = React.useMemo(() => {
+    let innerName = "unknown";
+    let len = 0;
+
     if (typeName) {
       const match = typeName.match(/^\[(.+);\s*(\d+)\]$/);
       if (match) {
-        return { innerTypeName: match[1].trim(), length: parseInt(match[2], 10) };
+        innerName = match[1].trim();
+        len = parseInt(match[2], 10);
       }
     }
     // Fallback: try to get from registry
-    if (client && typeId !== undefined) {
+    if (len === 0 && client && typeId !== undefined) {
       try {
         const typeInfo = client.registry.findType(typeId);
         if (typeInfo.typeDef.type === "SizedVec") {
-          const len = typeInfo.typeDef.value.len;
+          len = typeInfo.typeDef.value.len;
           const elemTypeId = typeInfo.typeDef.value.typeParam;
           const elemType = client.registry.findType(elemTypeId);
-          const elemName = elemType.path?.join("::") || elemType.typeDef.type || "Element";
-          return { innerTypeName: elemName, length: len };
+          innerName = elemType.path?.join("::") || elemType.typeDef.type || "Element";
         }
       } catch {
         // fallback
       }
     }
-    return { innerTypeName: "unknown", length: 0 };
+
+    const isU8 = innerName === "u8";
+    return { innerTypeName: innerName, length: len, isU8Array: isU8 };
   }, [typeName, client, typeId]);
 
+  // --- Byte array mode (for [u8; N]) ---
+  const [byteMode, setByteMode] = React.useState<ByteMode>("hex");
+  const [hexInput, setHexInput] = React.useState("");
+  const [base64Input, setBase64Input] = React.useState("");
+  const [byteError, setByteError] = React.useState<string | null>(null);
+
+  // Sync from external value for byte array mode
+  React.useEffect(() => {
+    if (!isU8Array || !externalValue) return;
+    if (Array.isArray(externalValue) && externalValue.length === length) {
+      const bytes = new Uint8Array(externalValue as number[]);
+      const hex = bytesToHex(bytes);
+      setHexInput(hex);
+      setBase64Input(bytesToBase64(bytes));
+      setByteError(null);
+    }
+  }, [externalValue, isU8Array, length]);
+
+  const emitByteArray = (bytes: Uint8Array) => {
+    onChange?.(Array.from(bytes));
+  };
+
+  const handleHexChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value.trim().toLowerCase();
+    const val = raw && !raw.startsWith("0x") ? `0x${raw}` : raw;
+    setHexInput(val);
+
+    if (!val || val === "0x") {
+      setByteError(null);
+      onChange?.(undefined);
+      return;
+    }
+
+    const bytes = hexToBytes(val);
+    if (!bytes) {
+      setByteError("Invalid hex string");
+      return;
+    }
+    if (bytes.length !== length) {
+      setByteError(`Expected ${length} bytes, got ${bytes.length}`);
+      return;
+    }
+    setByteError(null);
+    setBase64Input(bytesToBase64(bytes));
+    emitByteArray(bytes);
+  };
+
+  const handleBase64Change = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value.trim();
+    setBase64Input(raw);
+
+    if (!raw) {
+      setByteError(null);
+      onChange?.(undefined);
+      return;
+    }
+
+    const bytes = base64ToBytes(raw);
+    if (!bytes) {
+      setByteError("Invalid Base64 string");
+      return;
+    }
+    if (bytes.length !== length) {
+      setByteError(`Expected ${length} bytes, got ${bytes.length}`);
+      return;
+    }
+    setByteError(null);
+    setHexInput(bytesToHex(bytes));
+    emitByteArray(bytes);
+  };
+
+  // --- Per-element mode (for non-u8 types) ---
   const [values, setValues] = React.useState<unknown[]>(() =>
     new Array(length).fill(undefined)
   );
 
   // Reset when length changes
   React.useEffect(() => {
-    if (length > 0 && values.length !== length) {
+    if (!isU8Array && length > 0 && values.length !== length) {
       setValues(new Array(length).fill(undefined));
     }
-  }, [length, values.length]);
+  }, [length, values.length, isU8Array]);
+
+  // Sync from external value for per-element mode
+  React.useEffect(() => {
+    if (isU8Array) return;
+    if (externalValue && Array.isArray(externalValue) && externalValue.length === length) {
+      setValues(externalValue);
+    }
+  }, [externalValue, isU8Array, length]);
 
   const handleItemChange = (index: number, value: unknown) => {
     const newValues = [...values];
@@ -67,7 +163,7 @@ export function VectorFixed({
     onChange?.(newValues);
   };
 
-  const resolved = innerTypeName ? findComponent(innerTypeName) : null;
+  const resolved = !isU8Array && innerTypeName ? findComponent(innerTypeName) : null;
 
   if (length === 0) {
     return (
@@ -84,6 +180,59 @@ export function VectorFixed({
     );
   }
 
+  // Byte array mode for [u8; N]
+  if (isU8Array) {
+    const displayError = byteError || error;
+    return (
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Label htmlFor={name}>
+              {label}
+              {isRequired && <span className="text-red-500 ml-1">*</span>}
+            </Label>
+            <span className="text-xs text-muted-foreground">
+              ({length} bytes)
+            </span>
+          </div>
+          <ModeToggle
+            modes={[
+              { id: "hex", label: "Hex" },
+              { id: "base64", label: "Base64" },
+            ]}
+            activeMode={byteMode}
+            onModeChange={(m) => setByteMode(m as ByteMode)}
+            disabled={isDisabled}
+          />
+        </div>
+        {byteMode === "hex" ? (
+          <Input
+            id={name}
+            type="text"
+            disabled={isDisabled}
+            value={hexInput}
+            onChange={handleHexChange}
+            className="font-mono"
+            placeholder={`0x${"00".repeat(Math.min(length, 4))}...  (${length * 2} hex chars)`}
+          />
+        ) : (
+          <Input
+            id={name}
+            type="text"
+            disabled={isDisabled}
+            value={base64Input}
+            onChange={handleBase64Change}
+            className="font-mono"
+            placeholder={`Base64 string (decodes to ${length} bytes)`}
+          />
+        )}
+        {description && <FormDescription>{description}</FormDescription>}
+        {displayError && <p className="text-sm text-red-500">{displayError}</p>}
+      </div>
+    );
+  }
+
+  // Per-element mode for non-u8 types
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
@@ -105,6 +254,7 @@ export function VectorFixed({
                 label={`[${index}]`}
                 typeId={typeId}
                 isDisabled={isDisabled}
+                value={values[index]}
                 onChange={(v: unknown) => handleItemChange(index, v)}
               />
             ) : (

--- a/components/params/inputs/vector.tsx
+++ b/components/params/inputs/vector.tsx
@@ -2,11 +2,14 @@ import React from "react";
 import { z } from "zod";
 import { Label } from "@/components/ui/label";
 import { FormDescription } from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { Plus, Trash2 } from "lucide-react";
+import { Plus, Trash2, ChevronUp, ChevronDown } from "lucide-react";
 import type { ParamInputProps } from "../types";
 import { validateVectorConstraints } from "@/lib/validation";
 import { findComponent } from "@/lib/input-map";
+import { ModeToggle } from "@/components/params/shared/mode-toggle";
+import { parseJsonBulk, parseSeparatedValues } from "@/lib/bulk-parse";
 
 interface VectorProps extends ParamInputProps {
   children?: React.ReactNode;
@@ -15,6 +18,8 @@ interface VectorProps extends ParamInputProps {
 }
 
 const schema = z.array(z.any());
+
+type VectorMode = "form" | "bulk";
 
 export function Vector({
   name,
@@ -33,6 +38,11 @@ export function Vector({
 }: VectorProps) {
   const [items, setItems] = React.useState<any[]>([undefined]);
   const [validationError, setValidationError] = React.useState<string | null>(null);
+  const [mode, setMode] = React.useState<VectorMode>("form");
+  const [bulkText, setBulkText] = React.useState("");
+  const [bulkError, setBulkError] = React.useState<string | null>(null);
+  const [duplicateWarning, setDuplicateWarning] = React.useState<string | null>(null);
+  const lastEmittedRef = React.useRef<string>("");
 
   // Resolve the inner element type from metadata
   const innerType = React.useMemo(() => {
@@ -58,13 +68,38 @@ export function Vector({
   }, [client, typeId]);
 
   // Sync from external value (e.g., after hex decode)
+  // Skip if the external value matches what we last emitted (avoids overriding local state)
   React.useEffect(() => {
     if (externalValue !== undefined && externalValue !== null && Array.isArray(externalValue)) {
-      if (externalValue.length > 0) {
+      const externalStr = JSON.stringify(externalValue);
+      if (externalStr !== lastEmittedRef.current && externalValue.length > 0) {
         setItems(externalValue);
       }
     }
   }, [externalValue]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Check for duplicates whenever items change
+  React.useEffect(() => {
+    const defined = items.filter((item) => item !== undefined);
+    if (defined.length < 2) {
+      setDuplicateWarning(null);
+      return;
+    }
+    const strings = defined.map((v) => JSON.stringify(v));
+    const seen = new Map<string, number[]>();
+    strings.forEach((s, i) => {
+      const existing = seen.get(s);
+      if (existing) existing.push(i);
+      else seen.set(s, [i]);
+    });
+    const dupes = Array.from(seen.values()).filter((positions) => positions.length > 1);
+    if (dupes.length > 0) {
+      const positions = dupes.flat().join(", ");
+      setDuplicateWarning(`Duplicate values at positions ${positions}`);
+    } else {
+      setDuplicateWarning(null);
+    }
+  }, [items]);
 
   const validateAndEmit = (newItems: any[]) => {
     // Validate constraints
@@ -82,7 +117,9 @@ export function Vector({
     }
 
     // Always emit the current values (even if invalid) so parent can track state
-    onChange?.(newItems.filter((item) => item !== undefined));
+    const defined = newItems.filter((item) => item !== undefined);
+    lastEmittedRef.current = JSON.stringify(defined);
+    onChange?.(defined);
   };
 
   const handleAdd = () => {
@@ -104,6 +141,82 @@ export function Vector({
     newItems[index] = value;
     setItems(newItems);
     validateAndEmit(newItems);
+  };
+
+  const handleMoveUp = (index: number) => {
+    if (index === 0) return;
+    const newItems = [...items];
+    [newItems[index - 1], newItems[index]] = [newItems[index], newItems[index - 1]];
+    setItems(newItems);
+    validateAndEmit(newItems);
+  };
+
+  const handleMoveDown = (index: number) => {
+    if (index >= items.length - 1) return;
+    const newItems = [...items];
+    [newItems[index], newItems[index + 1]] = [newItems[index + 1], newItems[index]];
+    setItems(newItems);
+    validateAndEmit(newItems);
+  };
+
+  const handleModeChange = (newMode: string) => {
+    const m = newMode as VectorMode;
+    if (m === "bulk") {
+      // Pre-populate bulk text from current items
+      const defined = items.filter((item) => item !== undefined);
+      if (defined.length > 0) {
+        try {
+          setBulkText(JSON.stringify(defined, null, 2));
+        } catch {
+          setBulkText(defined.map(String).join("\n"));
+        }
+      }
+    } else if (m === "form" && bulkText.trim()) {
+      // Try to parse bulk text back to items
+      const jsonResult = parseJsonBulk(bulkText);
+      if (jsonResult.success) {
+        setItems(jsonResult.values);
+        validateAndEmit(jsonResult.values);
+      } else {
+        const lineResult = parseSeparatedValues(bulkText);
+        if (lineResult.success && lineResult.count > 0) {
+          setItems(lineResult.values);
+          validateAndEmit(lineResult.values);
+        }
+      }
+      setBulkError(null);
+    }
+    setMode(m);
+  };
+
+  const handleBulkTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const text = e.target.value;
+    setBulkText(text);
+
+    if (!text.trim()) {
+      setBulkError(null);
+      return;
+    }
+
+    // Try JSON first
+    const jsonResult = parseJsonBulk(text);
+    if (jsonResult.success) {
+      setBulkError(null);
+      setItems(jsonResult.values);
+      validateAndEmit(jsonResult.values);
+      return;
+    }
+
+    // Try line-separated
+    const lineResult = parseSeparatedValues(text);
+    if (lineResult.success && lineResult.count > 0) {
+      setBulkError(null);
+      setItems(lineResult.values);
+      validateAndEmit(lineResult.values);
+      return;
+    }
+
+    setBulkError(jsonResult.error || "Could not parse input");
   };
 
   // Clone the child component for each item
@@ -146,8 +259,30 @@ export function Vector({
       }
 
       return (
-        <div key={index} className="flex items-start gap-2">
+        <div key={index} className="flex items-start gap-1">
           <div className="flex-1">{itemComponent}</div>
+          {!isDisabled && (
+            <div className="flex flex-col gap-0.5 mt-8">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={() => handleMoveUp(index)}
+                disabled={index === 0}
+              >
+                <ChevronUp className="h-3 w-3" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={() => handleMoveDown(index)}
+                disabled={index >= items.length - 1}
+              >
+                <ChevronDown className="h-3 w-3" />
+              </Button>
+            </div>
+          )}
           {!isDisabled && items.length > minItems && (
             <Button
               variant="ghost"
@@ -164,7 +299,7 @@ export function Vector({
   };
 
   const canAddMore = !maxItems || items.length < maxItems;
-  const displayError = externalError || validationError;
+  const displayError = externalError || validationError || (mode === "bulk" ? bulkError : null);
 
   return (
     <div className="flex flex-col gap-2">
@@ -182,21 +317,47 @@ export function Vector({
             </span>
           )}
         </div>
-        {!isDisabled && canAddMore && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleAdd}
-            className="flex items-center gap-1"
-          >
-            <Plus className="h-4 w-4" />
-            Add Item
-          </Button>
-        )}
+        <div className="flex items-center gap-2">
+          <ModeToggle
+            modes={[
+              { id: "form", label: "Form" },
+              { id: "bulk", label: "Bulk" },
+            ]}
+            activeMode={mode}
+            onModeChange={handleModeChange}
+            disabled={isDisabled}
+          />
+          {mode === "form" && !isDisabled && canAddMore && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleAdd}
+              className="flex items-center gap-1"
+            >
+              <Plus className="h-4 w-4" />
+              Add
+            </Button>
+          )}
+        </div>
       </div>
-      <div className="flex flex-col gap-2">
-        {renderItems()}
-      </div>
+
+      {mode === "form" ? (
+        <div className="flex flex-col gap-2">
+          {renderItems()}
+        </div>
+      ) : (
+        <Textarea
+          disabled={isDisabled}
+          value={bulkText}
+          onChange={handleBulkTextChange}
+          className={`font-mono min-h-[120px] ${bulkError ? "border-red-500" : ""}`}
+          placeholder={'Paste JSON array or one value per line:\n["value1", "value2"]\nor\nvalue1\nvalue2'}
+        />
+      )}
+
+      {duplicateWarning && mode === "form" && (
+        <p className="text-xs text-yellow-600">{duplicateWarning}</p>
+      )}
       {description && <FormDescription>{description}</FormDescription>}
       {displayError && <p className="text-sm text-red-500">{displayError}</p>}
     </div>

--- a/components/params/inputs/vote.tsx
+++ b/components/params/inputs/vote.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { z } from "zod";
 import { Label } from "@/components/ui/label";
 import { FormDescription } from "@/components/ui/form";
+import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -9,13 +10,34 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Input } from "@/components/ui/input";
+import { ThumbsUp, ThumbsDown } from "lucide-react";
+import { cn } from "@/lib/utils";
 import type { ParamInputProps } from "../types";
+import { Balance } from "./balance";
 
-const schema = z.object({
-  aye: z.boolean(),
-  conviction: z.number().min(0).max(6),
-});
+type VoteMode = "Standard" | "Split" | "SplitAbstain";
+type VoteDirection = "aye" | "nay";
+
+const schema = z.any();
+
+const CONVICTION_INFO: Record<number, string> = {
+  0: "No lock period",
+  1: "Lock for 1 enactment period (~28 days)",
+  2: "Lock for 2x enactment (~56 days)",
+  3: "Lock for 4x enactment (~112 days)",
+  4: "Lock for 8x enactment (~224 days)",
+  5: "Lock for 16x enactment (~448 days)",
+  6: "Lock for 32x enactment (~896 days)",
+};
+
+/**
+ * Encode vote direction + conviction into a single byte (PalletConvictionVotingVote).
+ * High bit (0x80) = aye, low bits = conviction (0-6).
+ */
+function encodeVoteByte(direction: VoteDirection, conviction: number): number {
+  const base = direction === "aye" ? 0x80 : 0x00;
+  return base | (conviction & 0x7f);
+}
 
 export function Vote({
   name,
@@ -25,65 +47,209 @@ export function Vote({
   isRequired,
   error,
   onChange,
+  client,
 }: ParamInputProps) {
-  const [vote, setVote] = React.useState<{ aye: boolean; conviction: number }>({
-    aye: true,
-    conviction: 0,
-  });
+  const [mode, setMode] = React.useState<VoteMode>("Standard");
+  const [direction, setDirection] = React.useState<VoteDirection>("aye");
+  const [conviction, setConviction] = React.useState(0);
+  const [balance, setBalance] = React.useState<string | undefined>(undefined);
+  const [ayeBalance, setAyeBalance] = React.useState<string | undefined>(undefined);
+  const [nayBalance, setNayBalance] = React.useState<string | undefined>(undefined);
+  const [abstainBalance, setAbstainBalance] = React.useState<string | undefined>(undefined);
 
-  const handleVoteChange = (value: string) => {
-    const newVote = { ...vote, aye: value === "aye" };
-    setVote(newVote);
-    onChange?.(newVote);
+  const handleBalanceChange = React.useCallback((v: unknown) => setBalance(v as string | undefined), []);
+  const handleAyeChange = React.useCallback((v: unknown) => setAyeBalance(v as string | undefined), []);
+  const handleNayChange = React.useCallback((v: unknown) => setNayBalance(v as string | undefined), []);
+  const handleAbstainChange = React.useCallback((v: unknown) => setAbstainBalance(v as string | undefined), []);
+
+  // Emit the proper AccountVote enum value whenever state changes
+  const emitValue = React.useCallback(() => {
+    if (mode === "Standard") {
+      onChange?.({
+        type: "Standard",
+        value: {
+          vote: encodeVoteByte(direction, conviction),
+          balance: balance ?? "0",
+        },
+      });
+    } else if (mode === "Split") {
+      onChange?.({
+        type: "Split",
+        value: {
+          aye: ayeBalance ?? "0",
+          nay: nayBalance ?? "0",
+        },
+      });
+    } else {
+      onChange?.({
+        type: "SplitAbstain",
+        value: {
+          aye: ayeBalance ?? "0",
+          nay: nayBalance ?? "0",
+          abstain: abstainBalance ?? "0",
+        },
+      });
+    }
+  }, [mode, direction, conviction, balance, ayeBalance, nayBalance, abstainBalance, onChange]);
+
+  // Re-emit on any change
+  React.useEffect(() => {
+    emitValue();
+  }, [emitValue]);
+
+  const handleDirectionChange = (dir: VoteDirection) => {
+    setDirection(dir);
   };
 
   const handleConvictionChange = (value: string) => {
-    const conviction = parseInt(value);
-    const newVote = { ...vote, conviction };
-    setVote(newVote);
-    onChange?.(newVote);
+    setConviction(parseInt(value));
+  };
+
+  const handleModeChange = (newMode: string) => {
+    setMode(newMode as VoteMode);
   };
 
   return (
-    <div className="flex flex-col gap-2">
-      <Label htmlFor={name}>
-        {label}
-        {isRequired && <span className="text-red-500 ml-1">*</span>}
-      </Label>
-      <div className="grid grid-cols-2 gap-4">
-        <Select
-          disabled={isDisabled}
-          onValueChange={handleVoteChange}
-          value={vote.aye ? "aye" : "nay"}
-        >
-          <SelectTrigger id={`${name}-vote`}>
+    <div className="flex flex-col gap-2 pt-7">
+      <div className="flex items-center justify-between">
+        <Label htmlFor={name}>
+          {label}
+          {isRequired && <span className="text-red-500 ml-1">*</span>}
+        </Label>
+        <Select value={mode} onValueChange={handleModeChange} disabled={isDisabled}>
+          <SelectTrigger className="h-7 w-36 text-xs">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="aye">Aye</SelectItem>
-            <SelectItem value="nay">Nay</SelectItem>
-          </SelectContent>
-        </Select>
-
-        <Select
-          disabled={isDisabled}
-          onValueChange={handleConvictionChange}
-          value={vote.conviction.toString()}
-        >
-          <SelectTrigger id={`${name}-conviction`}>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="0">None</SelectItem>
-            <SelectItem value="1">Locked 1x</SelectItem>
-            <SelectItem value="2">Locked 2x</SelectItem>
-            <SelectItem value="3">Locked 3x</SelectItem>
-            <SelectItem value="4">Locked 4x</SelectItem>
-            <SelectItem value="5">Locked 5x</SelectItem>
-            <SelectItem value="6">Locked 6x</SelectItem>
+            <SelectItem value="Standard">Standard</SelectItem>
+            <SelectItem value="Split">Split</SelectItem>
+            <SelectItem value="SplitAbstain">Split Abstain</SelectItem>
           </SelectContent>
         </Select>
       </div>
+
+      {mode === "Standard" && (
+        <div className="flex flex-col gap-3">
+          {/* Vote direction buttons */}
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={isDisabled}
+              onClick={() => handleDirectionChange("aye")}
+              className={cn(
+                "flex-1",
+                direction === "aye" && "bg-green-500/10 border-green-500 text-green-700 hover:bg-green-500/20 hover:text-green-700"
+              )}
+            >
+              <ThumbsUp className="h-4 w-4 mr-1.5" />
+              Aye
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={isDisabled}
+              onClick={() => handleDirectionChange("nay")}
+              className={cn(
+                "flex-1",
+                direction === "nay" && "bg-red-500/10 border-red-500 text-red-700 hover:bg-red-500/20 hover:text-red-700"
+              )}
+            >
+              <ThumbsDown className="h-4 w-4 mr-1.5" />
+              Nay
+            </Button>
+          </div>
+
+          {/* Conviction selector */}
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Conviction</label>
+            <Select
+              disabled={isDisabled}
+              onValueChange={handleConvictionChange}
+              value={conviction.toString()}
+            >
+              <SelectTrigger id={`${name}-conviction`}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="0">None (0.1x voting power)</SelectItem>
+                <SelectItem value="1">Locked 1x</SelectItem>
+                <SelectItem value="2">Locked 2x</SelectItem>
+                <SelectItem value="3">Locked 3x</SelectItem>
+                <SelectItem value="4">Locked 4x</SelectItem>
+                <SelectItem value="5">Locked 5x</SelectItem>
+                <SelectItem value="6">Locked 6x</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground mt-1">
+              {CONVICTION_INFO[conviction]}
+            </p>
+          </div>
+
+          {/* Balance */}
+          <Balance
+            client={client}
+            name={`${name}-balance`}
+            label="Balance"
+            isDisabled={isDisabled}
+            onChange={handleBalanceChange}
+            value={balance}
+          />
+        </div>
+      )}
+
+      {mode === "Split" && (
+        <div className="flex flex-col gap-3">
+          <Balance
+            client={client}
+            name={`${name}-aye`}
+            label="Aye balance"
+            isDisabled={isDisabled}
+            onChange={handleAyeChange}
+            value={ayeBalance}
+          />
+          <Balance
+            client={client}
+            name={`${name}-nay`}
+            label="Nay balance"
+            isDisabled={isDisabled}
+            onChange={handleNayChange}
+            value={nayBalance}
+          />
+        </div>
+      )}
+
+      {mode === "SplitAbstain" && (
+        <div className="flex flex-col gap-3">
+          <Balance
+            client={client}
+            name={`${name}-aye`}
+            label="Aye balance"
+            isDisabled={isDisabled}
+            onChange={handleAyeChange}
+            value={ayeBalance}
+          />
+          <Balance
+            client={client}
+            name={`${name}-nay`}
+            label="Nay balance"
+            isDisabled={isDisabled}
+            onChange={handleNayChange}
+            value={nayBalance}
+          />
+          <Balance
+            client={client}
+            name={`${name}-abstain`}
+            label="Abstain balance"
+            isDisabled={isDisabled}
+            onChange={handleAbstainChange}
+            value={abstainBalance}
+          />
+        </div>
+      )}
+
       {description && <FormDescription>{description}</FormDescription>}
       {error && <p className="text-sm text-red-500">{error}</p>}
     </div>

--- a/components/params/shared/mode-toggle.tsx
+++ b/components/params/shared/mode-toggle.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+export interface ModeOption {
+  id: string;
+  label: string;
+}
+
+interface ModeToggleProps {
+  modes: ModeOption[];
+  activeMode: string;
+  onModeChange: (mode: string) => void;
+  disabled?: boolean;
+}
+
+export function ModeToggle({ modes, activeMode, onModeChange, disabled }: ModeToggleProps) {
+  return (
+    <div className="flex gap-1">
+      {modes.map((m) => (
+        <button
+          key={m.id}
+          type="button"
+          onClick={() => onModeChange(m.id)}
+          disabled={disabled}
+          className={`px-2 py-0.5 text-xs rounded-full border transition-colors ${
+            activeMode === m.id
+              ? "bg-primary text-primary-foreground border-primary"
+              : "bg-background text-muted-foreground border-input hover:bg-accent"
+          }`}
+        >
+          {m.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/lib/bulk-parse.ts
+++ b/lib/bulk-parse.ts
@@ -1,0 +1,68 @@
+/**
+ * JSON/CSV/line-based bulk parsing for vector and map input components.
+ */
+
+export interface BulkParseResult {
+  success: boolean;
+  values: unknown[];
+  error?: string;
+  count: number;
+}
+
+/**
+ * Parse a JSON string into an array of values.
+ * When expectPairs is true, accepts both `{"key":"value"}` objects and `[["key","value"]]` arrays.
+ */
+export function parseJsonBulk(input: string, expectPairs?: boolean): BulkParseResult {
+  const trimmed = input.trim();
+  if (!trimmed) return { success: false, values: [], error: "Empty input", count: 0 };
+
+  try {
+    const parsed = JSON.parse(trimmed);
+
+    if (expectPairs) {
+      // Accept object form: {"key1": "val1", "key2": "val2"} → [[key1, val1], [key2, val2]]
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const entries = Object.entries(parsed);
+        return { success: true, values: entries, count: entries.length };
+      }
+      // Accept array of pairs: [["key1", "val1"], ["key2", "val2"]]
+      if (Array.isArray(parsed)) {
+        const valid = parsed.every(
+          (item) => Array.isArray(item) && item.length === 2
+        );
+        if (!valid) {
+          return { success: false, values: [], error: "Expected array of [key, value] pairs", count: 0 };
+        }
+        return { success: true, values: parsed, count: parsed.length };
+      }
+      return { success: false, values: [], error: "Expected object or array of pairs", count: 0 };
+    }
+
+    // Plain array mode
+    if (Array.isArray(parsed)) {
+      return { success: true, values: parsed, count: parsed.length };
+    }
+    return { success: false, values: [], error: "Expected JSON array", count: 0 };
+  } catch (e) {
+    return { success: false, values: [], error: "Invalid JSON", count: 0 };
+  }
+}
+
+/**
+ * Parse a multi-line or separator-delimited string into an array of trimmed, non-empty values.
+ */
+export function parseSeparatedValues(
+  input: string,
+  separator: RegExp = /[\n,]/
+): BulkParseResult {
+  const trimmed = input.trim();
+  if (!trimmed) return { success: false, values: [], error: "Empty input", count: 0 };
+
+  const values = trimmed
+    .split(separator)
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+
+  return { success: true, values, count: values.length };
+}

--- a/lib/byte-utils.ts
+++ b/lib/byte-utils.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared hex/bytes/base64 conversion utilities.
+ * Used by Bytes, VectorFixed, and other byte-oriented input components.
+ */
+
+export function bytesToHex(bytes: Uint8Array): string {
+  if (bytes.length === 0) return "";
+  return "0x" + Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export function hexToBytes(hex: string): Uint8Array | null {
+  const stripped = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (stripped.length === 0) return new Uint8Array(0);
+  if (stripped.length % 2 !== 0) return null;
+  if (!/^[0-9a-fA-F]+$/.test(stripped)) return null;
+  const bytes = new Uint8Array(stripped.length / 2);
+  for (let i = 0; i < stripped.length; i += 2) {
+    bytes[i / 2] = parseInt(stripped.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+export function tryDecodeUtf8(hex: string): string | null {
+  const bytes = hexToBytes(hex);
+  if (!bytes || bytes.length === 0) return null;
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    // Reject if it contains control characters (except newline/tab) — likely binary
+    if (/[\x00-\x08\x0B\x0C\x0E-\x1F]/.test(text)) return null;
+    return text;
+  } catch {
+    return null;
+  }
+}
+
+export function base64ToBytes(b64: string): Uint8Array | null {
+  try {
+    const binary = atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}

--- a/lib/input-map.ts
+++ b/lib/input-map.ts
@@ -124,7 +124,7 @@ const registry: ComponentRegistration[] = [
   {
     component: Vote,
     schema: Vote.schema,
-    patterns: ["Vote", /^Vote$/],
+    patterns: ["AccountVote", /^AccountVote/],
     priority: 60,
   },
   {

--- a/lib/paste-utils.ts
+++ b/lib/paste-utils.ts
@@ -1,0 +1,67 @@
+/**
+ * Centralized paste detection and auto-formatting helpers.
+ */
+
+export interface PasteTransform {
+  value: string;
+  transformed: boolean;
+  hint?: string;
+}
+
+/**
+ * Auto-prepend 0x to hex strings that are missing the prefix.
+ * Used by Hash and Bytes inputs.
+ */
+export function autoPrefix0x(raw: string): PasteTransform {
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) return { value: trimmed, transformed: false };
+
+  if (!trimmed.startsWith("0x") && /^[0-9a-f]+$/.test(trimmed)) {
+    return {
+      value: `0x${trimmed}`,
+      transformed: true,
+      hint: "Added 0x prefix",
+    };
+  }
+  return { value: trimmed, transformed: false };
+}
+
+/**
+ * Strip common numeric formatting characters (commas, spaces, underscores).
+ * Used by Amount and Balance inputs.
+ */
+export function stripNumericFormatting(raw: string): PasteTransform {
+  const trimmed = raw.trim();
+  if (!trimmed) return { value: trimmed, transformed: false };
+
+  const cleaned = trimmed.replace(/[,_ ]/g, "");
+  if (cleaned !== trimmed) {
+    return {
+      value: cleaned,
+      transformed: true,
+      hint: "Removed formatting characters",
+    };
+  }
+  return { value: trimmed, transformed: false };
+}
+
+/**
+ * Detect if a pasted value looks like planck (raw integer with many digits).
+ * Heuristic: if it's a pure integer string with more digits than chainDecimals,
+ * it's likely a planck value.
+ */
+export function detectPlanckPaste(
+  raw: string,
+  chainDecimals: number
+): { isPlanck: boolean; planckValue?: string } {
+  const trimmed = raw.trim().replace(/[,_ ]/g, "");
+  if (!trimmed || !/^\d+$/.test(trimmed)) {
+    return { isPlanck: false };
+  }
+
+  // If the number has more digits than chainDecimals + 2, it's likely planck
+  if (trimmed.length > chainDecimals + 2) {
+    return { isPlanck: true, planckValue: trimmed };
+  }
+  return { isPlanck: false };
+}


### PR DESCRIPTION
## Summary

Comprehensive UX improvements across all 21 input components, with shared infrastructure utilities and critical encoding bug fixes.

### Shared Infrastructure (new files)
- **`components/params/shared/mode-toggle.tsx`** — Reusable pill-button mode toggle (used by Bytes, VectorFixed, Amount, BTreeMap, BTreeSet)
- **`lib/byte-utils.ts`** — Hex/bytes/base64 conversion helpers
- **`lib/bulk-parse.ts`** — JSON/CSV bulk parsing for vector-like inputs
- **`lib/paste-utils.ts`** — Auto-prefix, numeric formatting, planck detection

### Input Component Improvements
- **Account** — Paste auto-format with visual confirmation
- **Amount** — Min/max range display per integer type, hex toggle for u128+, fix encoding to always emit strings
- **Balance** — 25%/50%/75%/Max percentage buttons, planck paste detection
- **Bytes** — JSON and Base64 modes alongside existing hex/text/file
- **BTreeMap/BTreeSet** — JSON bulk input mode
- **Call** — Pass client for proper nested type resolution
- **Enum** — Visual grouping of data-carrying variants, auto-select first variant, docs tooltips
- **Hash** — Auto `0x` prefix on paste, green/red validation icons
- **KeyValue** — Typed component resolution from metadata
- **Moment** — Now button, presets (+1h/6h/24h/7d), timezone display
- **Option** — Self-resolving inner type from metadata, hide child when None with animation
- **Struct** — Type annotation badges on field labels
- **Tuple** — Improved labels from type path names
- **Vector** — Reorder (up/down) buttons, bulk paste, duplicate detection
- **VectorFixed** — Byte array mode for `[u8;N]` with hex/base64 input
- **Vote** — Complete rewrite for AccountVote enum (Standard/Split/SplitAbstain), conviction voting with lock period info, thumbs up/down icons

### Bug Fixes
- **codec.ts** — Make `coerceValue` recursive for nested objects/arrays (fixes "Cannot mix BigInt and other types" error for AccountVote)
- **input-map.ts** — Update Vote pattern from `"Vote"` to `"AccountVote"` for correct type matching
- **amount.tsx** — Always emit string values so `coerceValue` can convert to BigInt (fixes u64 encoding)

## Test plan
- [x] All 174 tests pass (`yarn test`)
- [x] Production build succeeds (`yarn build`)
- [x] Browser tested: Amount (u64 encoding), Option (self-resolving ProxyType), Vote (AccountVote encoding with conviction)
- [ ] Full browser regression across all input types