### PR TITLE
Add interactive component previews to docs

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -7,6 +7,9 @@ import {
 } from "fumadocs-ui/page";
 import { notFound } from "next/navigation";
 import defaultMdxComponents from "fumadocs-ui/mdx";
+import { ComponentPreview } from "@/components/docs/component-preview";
+import { AccountDemo, BalanceDemo, EnumDemo } from "@/components/docs/demos";
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
@@ -25,6 +28,12 @@ export default async function Page(props: {
         <MDX
           components={{
             ...defaultMdxComponents,
+            ComponentPreview,
+            AccountDemo,
+            BalanceDemo,
+            EnumDemo,
+            Tab,
+            Tabs,
           }}
         />
       </DocsBody>

--- a/components/docs/component-preview.tsx
+++ b/components/docs/component-preview.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface ComponentPreviewProps {
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export function ComponentPreview({ children, className }: ComponentPreviewProps) {
+  return (
+    <div
+      className={cn(
+        "not-prose flex min-h-[200px] items-center justify-center rounded-lg border bg-background p-6",
+        className
+      )}
+    >
+      {children || (
+        <p className="text-sm text-muted-foreground italic">
+          Live preview requires a chain connection. See the Builder page for interactive usage.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/docs/demos/account-demo.tsx
+++ b/components/docs/demos/account-demo.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import React, { useState, useCallback } from "react";
+import { Label } from "@/components/ui/label";
+import {
+  AccountCombobox,
+  type AccountOption,
+} from "@/components/params/inputs/account-combobox";
+import { encodeAddress, decodeAddress } from "dedot/utils";
+
+const SS58_PREFIX = 0; // Polkadot
+
+const DEMO_ACCOUNTS: AccountOption[] = [
+  { address: "15oF4uVJwmo4TdGW7VfQxNLavjCXviqWrztPu6BsCNqHXSSR", name: "Alice" },
+  { address: "14E5nqKAp3oAJcg6bNbGNMftfM7DqE1RK3v8cPmiv8gdGTYe", name: "Bob" },
+  { address: "13UVJyLnbVp77Z2t6qZP4toyodigy3RVxCqLg8cEmFQtvCnB", name: "Charlie" },
+];
+
+const RECENT_ADDRESSES = [
+  "16ZL8yLg6tiiYvqFCyS3FLNyGsX7u8XfXfNwiiNRU6hNBQKH",
+];
+
+function formatAddress(addr: string): string | null {
+  try {
+    const pubkey = decodeAddress(addr);
+    return encodeAddress(pubkey, SS58_PREFIX);
+  } catch {
+    return null;
+  }
+}
+
+function isValidAddress(addr: string): boolean {
+  try {
+    decodeAddress(addr);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function truncateAddress(addr: string): string {
+  if (addr.length <= 16) return addr;
+  return `${addr.slice(0, 6)}...${addr.slice(-6)}`;
+}
+
+export function AccountDemo() {
+  const [value, setValue] = useState<string | undefined>();
+
+  const handleChange = useCallback((addr: string | undefined) => {
+    setValue(addr);
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-2 w-full max-w-md">
+      <Label>Destination</Label>
+      <AccountCombobox
+        value={value}
+        onChange={handleChange}
+        accounts={DEMO_ACCOUNTS}
+        recentAddresses={RECENT_ADDRESSES}
+        ss58Prefix={SS58_PREFIX}
+        formatAddress={formatAddress}
+        isValidAddress={isValidAddress}
+        truncateAddress={truncateAddress}
+        placeholder="Select an account..."
+      />
+    </div>
+  );
+}

--- a/components/docs/demos/balance-demo.tsx
+++ b/components/docs/demos/balance-demo.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import React, { useState, useCallback, useMemo } from "react";
+import { Label } from "@/components/ui/label";
+import { InputWithAddon } from "@/components/ui/input-with-addon";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  getDenominations,
+  toPlanck,
+  fromPlanck,
+  type Denomination,
+} from "@/lib/denominations";
+
+const SYMBOL = "DOT";
+const DECIMALS = 10;
+const TRANSFERABLE = BigInt("150000000000"); // 15 DOT
+const EXISTENTIAL_DEPOSIT = BigInt("10000000000"); // 1 DOT
+
+export function BalanceDemo() {
+  const denominations = useMemo(() => getDenominations(SYMBOL, DECIMALS), []);
+
+  const [displayValue, setDisplayValue] = useState("");
+  const [selectedDenomLabel, setSelectedDenomLabel] = useState(SYMBOL);
+
+  const selectedDenom: Denomination = useMemo(
+    () => denominations.find((d) => d.label === selectedDenomLabel) ?? denominations[0],
+    [selectedDenomLabel, denominations]
+  );
+
+  const isPlanck = selectedDenom.label === "planck";
+
+  const handleValueChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setDisplayValue(e.target.value);
+    },
+    []
+  );
+
+  const handleDenomChange = useCallback(
+    (newLabel: string) => {
+      const newDenom = denominations.find((d) => d.label === newLabel);
+      if (!newDenom) return;
+
+      if (displayValue.trim()) {
+        const currentPlanck = toPlanck(displayValue, selectedDenom);
+        if (currentPlanck) {
+          const converted = fromPlanck(currentPlanck, newDenom);
+          setDisplayValue(converted);
+        }
+      }
+
+      setSelectedDenomLabel(newLabel);
+    },
+    [denominations, displayValue, selectedDenom]
+  );
+
+  const handlePercentage = useCallback(
+    (percent: number) => {
+      let amount: bigint;
+      if (percent === 100) {
+        amount =
+          TRANSFERABLE > EXISTENTIAL_DEPOSIT
+            ? TRANSFERABLE - EXISTENTIAL_DEPOSIT
+            : BigInt(0);
+      } else {
+        amount = (TRANSFERABLE * BigInt(percent)) / BigInt(100);
+      }
+      const display = fromPlanck(amount.toString(), selectedDenom);
+      setDisplayValue(display);
+    },
+    [selectedDenom]
+  );
+
+  // ED warning
+  const showEdWarning = useMemo(() => {
+    if (!displayValue.trim()) return false;
+    const planck = toPlanck(displayValue, selectedDenom);
+    if (!planck) return false;
+    try {
+      const entered = BigInt(planck);
+      return TRANSFERABLE - entered < EXISTENTIAL_DEPOSIT && entered > BigInt(0);
+    } catch {
+      return false;
+    }
+  }, [displayValue, selectedDenom]);
+
+  const edDisplay = fromPlanck(EXISTENTIAL_DEPOSIT.toString(), selectedDenom);
+
+  const denomSelector = (
+    <Select value={selectedDenom.label} onValueChange={handleDenomChange}>
+      <SelectTrigger className="h-7 w-24 border-0 bg-muted/50 text-xs font-mono focus:ring-0 shadow-none">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {denominations.map((d) => (
+          <SelectItem key={d.label} value={d.label} className="text-xs font-mono">
+            {d.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+
+  return (
+    <div className="flex flex-col gap-2 w-full max-w-md">
+      <Label>Amount</Label>
+      <InputWithAddon
+        type="text"
+        inputMode={isPlanck ? "numeric" : "decimal"}
+        value={displayValue}
+        onChange={handleValueChange}
+        className="font-mono"
+        placeholder={isPlanck ? "0" : "0.00"}
+        suffix={denomSelector}
+      />
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>Available: 15 {SYMBOL}</span>
+        <div className="flex gap-1">
+          {[25, 50, 75].map((pct) => (
+            <Button
+              key={pct}
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-5 px-2 text-xs"
+              onClick={() => handlePercentage(pct)}
+            >
+              {pct}%
+            </Button>
+          ))}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-5 px-2 text-xs"
+            onClick={() => handlePercentage(100)}
+          >
+            Max
+          </Button>
+        </div>
+      </div>
+      {showEdWarning && (
+        <p className="text-xs text-yellow-600">
+          Amount would reap account (ED: {edDisplay} {selectedDenom.label})
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/docs/demos/enum-demo.tsx
+++ b/components/docs/demos/enum-demo.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import React, { useState } from "react";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface DemoVariant {
+  name: string;
+  docs: string;
+}
+
+const VARIANTS: DemoVariant[] = [
+  {
+    name: "SuperMajorityApprove",
+    docs: "A supermajority of aye votes is required to pass this motion.",
+  },
+  {
+    name: "SuperMajorityAgainst",
+    docs: "A supermajority of nay votes is required to reject this motion.",
+  },
+  {
+    name: "SimpleMajority",
+    docs: "A simple majority of votes is required.",
+  },
+];
+
+export function EnumDemo() {
+  const [selected, setSelected] = useState(VARIANTS[0].name);
+
+  return (
+    <div className="flex flex-col gap-2 w-full max-w-md">
+      <Label>Vote Threshold</Label>
+      <Select value={selected} onValueChange={setSelected}>
+        <SelectTrigger>
+          <SelectValue placeholder="Select variant" />
+        </SelectTrigger>
+        <SelectContent>
+          <TooltipProvider delayDuration={300}>
+            {VARIANTS.map((variant) => {
+              const item = (
+                <SelectItem key={variant.name} value={variant.name}>
+                  {variant.name}
+                </SelectItem>
+              );
+
+              return (
+                <Tooltip key={variant.name}>
+                  <TooltipTrigger asChild>{item}</TooltipTrigger>
+                  <TooltipContent side="right" className="max-w-xs text-xs">
+                    {variant.docs}
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </TooltipProvider>
+        </SelectContent>
+      </Select>
+      <p className="text-xs text-muted-foreground font-mono">
+        {"{"} type: &quot;{selected}&quot; {"}"}
+      </p>
+    </div>
+  );
+}

--- a/components/docs/demos/index.ts
+++ b/components/docs/demos/index.ts
@@ -1,0 +1,3 @@
+export { AccountDemo } from "./account-demo";
+export { BalanceDemo } from "./balance-demo";
+export { EnumDemo } from "./enum-demo";

--- a/content/docs/components/account-input.mdx
+++ b/content/docs/components/account-input.mdx
@@ -3,6 +3,29 @@ title: Account Input
 description: Address input with wallet integration and SS58 validation
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <AccountDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { Account } from "@/components/params/inputs/account";
+
+<Account
+  name="dest"
+  label="Destination"
+  description="The recipient account"
+  client={client}
+  typeId={0}
+  isRequired
+  onChange={(address) => console.log("Selected:", address)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Account Input
 
 The Account input provides a Substrate address field with connected wallet integration, recent address history, and SS58 format validation. It is used whenever a parameter expects an on-chain account identifier -- transfers, proxies, identity lookups, and any call that targets a specific address.

--- a/content/docs/components/balance-input.mdx
+++ b/content/docs/components/balance-input.mdx
@@ -3,6 +3,29 @@ title: Balance Input
 description: Token amount input with denomination selector and balance display
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <BalanceDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { Balance } from "@/components/params/inputs/balance";
+
+<Balance
+  name="value"
+  label="Amount"
+  description="The amount to transfer"
+  client={client}
+  typeId={6}
+  isRequired
+  onChange={(planck) => console.log("Planck value:", planck)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Balance Input
 
 The Balance input provides a denomination-aware numeric field for entering token amounts. It handles the conversion between human-readable values (e.g. `1.5 DOT`) and on-chain planck values (e.g. `15000000000`), displays the user's available balance, and warns when a transfer would drop the account below the existential deposit.

--- a/content/docs/components/enum-input.mdx
+++ b/content/docs/components/enum-input.mdx
@@ -3,6 +3,31 @@ title: Enum Input
 description: Variant selector for Substrate enum types with dynamic inner value resolution
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <EnumDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { Enum } from "@/components/params/inputs/enum";
+
+<Enum
+  name="threshold"
+  label="Vote Threshold"
+  client={client}
+  variants={[
+    { name: "SuperMajorityApprove", docs: ["A supermajority of aye votes..."] },
+    { name: "SuperMajorityAgainst", docs: ["A supermajority of nay votes..."] },
+    { name: "SimpleMajority", docs: ["A simple majority..."] },
+  ]}
+  onChange={(val) => console.log("Selected:", val)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Enum Input
 
 The Enum input handles all Substrate enum (variant) types from chain metadata. It presents a dropdown for selecting which variant is active, then dynamically renders the appropriate sub-inputs for that variant's fields. Enums are one of the most common composite types in Substrate -- used for calls, errors, events, and configuration options throughout every pallet.

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,9 +1,18 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
+import { ComponentPreview } from "@/components/docs/component-preview";
+import { AccountDemo, BalanceDemo, EnumDemo } from "@/components/docs/demos";
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 export function useMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
+    ComponentPreview,
+    AccountDemo,
+    BalanceDemo,
+    EnumDemo,
+    Tab,
+    Tabs,
     ...components,
   };
 }


### PR DESCRIPTION
## Summary

Adds live, interactive demo components to the Account, Balance, and Enum documentation pages following the shadcn/ui documentation pattern — each component page now has a Preview/Code tabbed section at the top.

**Depends on:** #15 (Fumadocs setup)

### Demo components

- **AccountDemo** — Uses the real `AccountCombobox` component with hardcoded Polkadot addresses (Alice, Bob, Charlie), identicons, and SS58 validation. No chain connection required.
- **BalanceDemo** — Standalone demo using the same UI primitives as the real Balance component. Features DOT denomination selector, percentage buttons (25%/50%/75%/Max), available balance display, and existential deposit warning.
- **EnumDemo** — Variant selector with VoteThreshold variants (SuperMajorityApprove, SuperMajorityAgainst, SimpleMajority) with documentation tooltips and live output display.

### Changes

- `components/docs/demos/` — 3 demo components + barrel export
- `components/docs/component-preview.tsx` — Preview container with theme-aware background
- Updated `mdx-components.tsx` and docs page to register demo components and Fumadocs Tabs
- Updated 3 component MDX files with Preview/Code tab blocks

## Test plan

- [ ] `/docs/components/account-input` — Preview tab shows interactive combobox with identicons
- [ ] `/docs/components/balance-input` — Preview shows amount input with denomination selector and percentage buttons
- [ ] `/docs/components/enum-input` — Preview shows variant dropdown with tooltips
- [ ] Code tabs show syntax-highlighted code with copy button
- [ ] Production build succeeds (`yarn build`)