### PR TITLE
Add docs for composite input components

### DIFF
--- a/content/docs/components/btree-map-input.mdx
+++ b/content/docs/components/btree-map-input.mdx
@@ -1,0 +1,89 @@
+---
+title: BTreeMap Input
+description: Key-value pair editor for Substrate BTreeMap types with JSON bulk entry
+---
+
+# BTreeMap Input
+
+The BTreeMap input handles Substrate `BTreeMap<K, V>` types by rendering a list of key-value pair editors. Each pair has its key and value types resolved from the chain metadata and rendered with the appropriate sub-input components. It supports both form mode for individual pair editing and a JSON mode for bulk entry. BTreeMaps appear in Substrate for configuration maps, storage deposits, and any parameter that expects an ordered key-value collection.
+
+## Supported Type Names
+
+The BTreeMap component matches the following type name pattern at **priority 42**:
+
+- Any type name matching `/^BTreeMap</` (e.g. `BTreeMap<AccountId32, Balance>`, `BTreeMap<u32, Vec<u8>>`)
+
+## Props
+
+The component extends `ParamInputProps` with a required `typeId`:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used as a prefix for pair IDs |
+| `label` | `string` | No | Display label shown above the editor |
+| `description` | `string` | No | Help text shown below the editor |
+| `typeName` | `string` | No | The SCALE type name (e.g. `"BTreeMap<u32, Balance>"`) |
+| `isDisabled` | `boolean` | No | Disables all controls and pair inputs |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client for resolving key and value types |
+| `typeId` | `number` | Yes | Metadata type ID for the BTreeMap type |
+| `value` | `any` | No | Externally controlled value |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the array of key-value tuples |
+
+## Features
+
+- **Auto-resolves key and value types**: Reads the BTreeMap's metadata structure (a `Sequence` of `Tuple`s in SCALE) to find the key and value type IDs, then resolves each to the correct input component via `findComponent`.
+- **Card-per-entry layout**: Each key-value pair renders inside its own `Card` with "Key" and "Value" labeled sub-inputs.
+- **Add/Remove entries**: An "Add Entry" button appends new pairs; each pair has a remove button (minimum one pair).
+- **JSON bulk mode**: A toggle switches between form mode and JSON mode, where users can paste a JSON object (`{"key": "value"}`) or an array of tuples (`[["key", "value"]]`).
+- **Bidirectional sync**: Switching between form and JSON modes preserves data by serializing/deserializing the current entries.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// Matched by /^BTreeMap</ at priority 42
+findComponent("BTreeMap<AccountId32, Balance>", 35, client);
+findComponent("BTreeMap<u32, Vec<u8>>", 40, client);
+```
+
+## Usage
+
+The BTreeMap component is rendered by the extrinsic builder when a parameter type starts with `BTreeMap<`. Direct usage:
+
+```tsx
+import { BTreeMap } from "@/components/params/inputs/btree-map";
+
+<BTreeMap
+  name="deposits"
+  label="Deposits"
+  description="Map of account deposits"
+  client={client}
+  typeId={35}
+  onChange={(val) => console.log("Map:", val)}
+/>
+```
+
+## Validation
+
+The component uses a Zod schema that expects an array of two-element tuples:
+
+```ts
+const schema = z.array(z.tuple([z.any(), z.any()]));
+```
+
+## Value Format
+
+The `onChange` callback receives an **array of `[key, value]` tuples**, filtered to only include pairs where both the key and value are defined:
+
+```ts
+// BTreeMap<u32, Balance>
+[["1", "1000000000000"], ["2", "2000000000000"]]
+
+// BTreeMap<AccountId32, bool>
+[["5GrwvaEF...", true], ["5FHneW46...", false]]
+```
+
+This matches the SCALE encoding format for `BTreeMap`, which serializes as a sequence of `(K, V)` tuples.

--- a/content/docs/components/btree-set-input.mdx
+++ b/content/docs/components/btree-set-input.mdx
@@ -1,0 +1,91 @@
+---
+title: BTreeSet Input
+description: Unique-value collection editor for Substrate BTreeSet types with duplicate detection
+---
+
+# BTreeSet Input
+
+The BTreeSet input handles Substrate `BTreeSet<T>` types by rendering a dynamic list of sub-inputs with automatic duplicate detection. Each item's type is resolved from the chain metadata and rendered with the appropriate component. It supports both form mode for individual item editing and a JSON mode for bulk entry. BTreeSets appear in Substrate wherever a parameter expects a collection of unique, ordered values.
+
+## Supported Type Names
+
+The BTreeSet component matches the following type name pattern at **priority 41**:
+
+- Any type name matching `/^BTreeSet</` (e.g. `BTreeSet<AccountId32>`, `BTreeSet<u32>`)
+
+## Props
+
+The component extends `ParamInputProps` with a required `typeId`:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used as a prefix for item IDs |
+| `label` | `string` | No | Display label shown above the list |
+| `description` | `string` | No | Help text shown below the list |
+| `typeName` | `string` | No | The SCALE type name (e.g. `"BTreeSet<AccountId32>"`) |
+| `isDisabled` | `boolean` | No | Disables all controls and item inputs |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client for resolving the element type |
+| `typeId` | `number` | Yes | Metadata type ID for the BTreeSet type |
+| `value` | `any` | No | Externally controlled value |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the array of unique values |
+
+## Features
+
+- **Auto-resolves element type**: Reads the BTreeSet's metadata structure (a `Sequence` in SCALE) to find the element type ID, then resolves it to the correct input component via `findComponent`.
+- **Duplicate detection**: After every change, compares items by JSON serialization and displays a validation error when duplicates are found.
+- **Add/Remove items**: An "Add Item" button appends new items; each item has a remove button (minimum one item).
+- **JSON bulk mode**: A toggle switches between form mode and JSON mode, where users can paste a JSON array of values.
+- **Bidirectional sync**: Switching between form and JSON modes preserves data by serializing/deserializing the current items.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// Matched by /^BTreeSet</ at priority 41
+findComponent("BTreeSet<AccountId32>", 22, client);
+findComponent("BTreeSet<u32>", 28, client);
+```
+
+## Usage
+
+The BTreeSet component is rendered by the extrinsic builder when a parameter type starts with `BTreeSet<`. Direct usage:
+
+```tsx
+import { BTreeSet } from "@/components/params/inputs/btree-set";
+
+<BTreeSet
+  name="validators"
+  label="Validator Set"
+  description="Set of unique validator accounts"
+  client={client}
+  typeId={22}
+  onChange={(val) => console.log("Set:", val)}
+/>
+```
+
+## Validation
+
+The component uses a Zod schema that expects an array of any values:
+
+```ts
+const schema = z.array(z.any());
+```
+
+Additionally, runtime validation checks for duplicate values using JSON serialization comparison and displays a "Set contains duplicate values" error when duplicates are detected.
+
+## Value Format
+
+The `onChange` callback receives an **array of defined values** (items that are `undefined` are filtered out):
+
+```ts
+// BTreeSet<AccountId32>
+["5GrwvaEF...", "5FHneW46...", "5DAAnrj7..."]
+
+// BTreeSet<u32>
+["1", "2", "3"]
+```
+
+The array should contain unique values. While the component warns about duplicates, it still emits the full array to let the parent track state.

--- a/content/docs/components/call-input.mdx
+++ b/content/docs/components/call-input.mdx
@@ -1,0 +1,123 @@
+---
+title: Call Input
+description: Nested extrinsic call builder for Substrate RuntimeCall parameters
+---
+
+# Call Input
+
+The Call input provides a nested extrinsic call builder for parameters that expect a `RuntimeCall` value. It presents pallet and method selectors followed by dynamic parameter inputs, effectively embedding a mini extrinsic builder inside a parameter field. Call inputs appear in Substrate for utility batch calls, proxy executions, multisig approvals, scheduler dispatches, and any extrinsic that wraps another call.
+
+## Supported Type Names
+
+The Call component matches the following type name patterns at **priority 70**:
+
+- `Call`
+- `RuntimeCall`
+- Any type name matching `/Call$/`
+- Any type name matching `/RuntimeCall>/`
+
+## Props
+
+The component accepts the standard `ParamInputProps` interface:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used as a prefix for nested field IDs |
+| `label` | `string` | No | Display label shown above the card |
+| `description` | `string` | No | Help text shown below the label |
+| `typeName` | `string` | No | The SCALE type name (e.g. `"RuntimeCall"`) |
+| `isDisabled` | `boolean` | No | Disables the pallet/method selectors and all parameter inputs |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client for reading pallets, methods, and parameter types |
+| `typeId` | `number` | No | Metadata type ID |
+| `value` | `any` | No | Externally controlled value |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the call structure |
+
+## Features
+
+- **Pallet selector**: A searchable combobox lists all pallets from the chain metadata.
+- **Method selector**: After selecting a pallet, a second combobox lists all callable methods (extrinsics) for that pallet.
+- **Dynamic parameter inputs**: Once a method is selected, its parameters are resolved from the metadata and rendered using `findComponent`, creating a fully recursive call builder.
+- **Auto-reset**: Changing the pallet resets the method and arguments. Changing the method resets the arguments.
+- **No-params indicator**: Methods with no parameters display an informational message instead of empty space.
+- **Recursive nesting**: Since Call uses `findComponent` for its parameters, nested calls (e.g. `utility.batch` containing more calls) are fully supported.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// Matched by exact strings and regex patterns at priority 70
+findComponent("Call", 100, client);
+findComponent("RuntimeCall", 100, client);
+findComponent("Box<RuntimeCall>", 100, client);
+```
+
+## Usage
+
+The Call component is rendered by the extrinsic builder when a parameter type matches a call pattern. Direct usage:
+
+```tsx
+import { Call } from "@/components/params/inputs/call";
+
+<Call
+  name="call"
+  label="Proposal Call"
+  description="The call to be executed"
+  client={client}
+  onChange={(val) => console.log("Call:", val)}
+/>
+```
+
+## Validation
+
+The component uses a Zod schema that expects an object with a `type` string and a `value`:
+
+```ts
+const schema = z.object({
+  type: z.string(),
+  value: z.any(),
+});
+```
+
+## Value Format
+
+The `onChange` callback receives a **nested call structure** in the format Dedot expects:
+
+```ts
+// utility.batch call
+{
+  type: "utility",
+  value: {
+    type: "batch",
+    calls: [...]
+  }
+}
+
+// balances.transferKeepAlive call
+{
+  type: "balances",
+  value: {
+    type: "transferKeepAlive",
+    dest: "5GrwvaEF...",
+    value: "1000000000000"
+  }
+}
+
+// proxy.proxy wrapping a call
+{
+  type: "proxy",
+  value: {
+    type: "proxy",
+    real: "5GrwvaEF...",
+    forceProxyType: undefined,
+    call: {
+      type: "balances",
+      value: { type: "transferKeepAlive", dest: "...", value: "..." }
+    }
+  }
+}
+```
+
+The `type` field at the top level is the camelCase pallet name. The nested `value.type` is the camelCase method name. All method arguments are spread into the `value` object alongside `type`.

--- a/content/docs/components/option-input.mdx
+++ b/content/docs/components/option-input.mdx
@@ -1,0 +1,94 @@
+---
+title: Option Input
+description: Toggle-based wrapper for Substrate Option<T> types with automatic inner type resolution
+---
+
+# Option Input
+
+The Option input handles Substrate `Option<T>` types by presenting a toggle switch that lets the user choose between `None` (disabled) and `Some(value)` (enabled). When enabled, it automatically resolves and renders the appropriate sub-input for the inner type `T` using chain metadata. Options appear throughout Substrate pallets wherever a parameter is not strictly required -- tips, era selection, and optional configuration fields.
+
+## Supported Type Names
+
+The Option component matches the following type name patterns at **priority 45**:
+
+- Any type name matching `/^Option</` (e.g. `Option<u128>`, `Option<AccountId32>`, `Option<BalanceOf>`)
+
+## Props
+
+The component extends `ParamInputProps` with an optional `children` prop:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used for the HTML `id` and form state |
+| `label` | `string` | No | Display label shown above the toggle |
+| `description` | `string` | No | Help text shown below the component |
+| `typeName` | `string` | No | The SCALE type name (e.g. `"Option<AccountId32>"`) |
+| `isDisabled` | `boolean` | No | Disables the toggle and inner input |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client for resolving the inner type from metadata |
+| `typeId` | `number` | No | Metadata type ID for the Option type |
+| `value` | `any` | No | Externally controlled value (e.g. from hex decode) |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the inner value or `undefined` |
+| `children` | `React.ReactNode` | No | Legacy: explicit child component instead of metadata resolution |
+
+## Features
+
+- **None/Some toggle**: A switch control toggles between `None` (off) and `Some` (on). When off, `undefined` is emitted. When on, the inner input is shown.
+- **Auto-resolves inner type**: Reads the Option's enum definition from chain metadata to find the `Some` variant's inner type, then uses `findComponent` to render the correct input.
+- **Animated transition**: The inner input slides in and out using Framer Motion when the toggle changes.
+- **External value sync**: If a value is provided externally (e.g. from hex decoding), the toggle automatically enables.
+- **Legacy children support**: Can accept explicit child components that are cloned with the appropriate props.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// Matched by the /^Option</ pattern at priority 45
+findComponent("Option<AccountId32>", 10, client);
+findComponent("Option<u128>", 15, client);
+findComponent("Option<BalanceOf>", 20, client);
+```
+
+## Usage
+
+The Option component is rendered by the extrinsic builder when a parameter type starts with `Option<`. Direct usage:
+
+```tsx
+import { Option } from "@/components/params/inputs/option";
+
+<Option
+  name="tip"
+  label="Tip"
+  description="Optional tip for the block author"
+  client={client}
+  typeId={10}
+  onChange={(val) => console.log("Value:", val)}
+/>
+```
+
+## Validation
+
+The component uses a permissive Zod schema since the inner value validation is delegated to the resolved sub-component:
+
+```ts
+const schema = z.any().optional();
+```
+
+## Value Format
+
+The `onChange` callback receives the **inner value directly** when the toggle is on, or `undefined` when toggled off:
+
+```ts
+// Toggle off (None)
+undefined
+
+// Toggle on (Some) with an AccountId inner type
+"5GrwvaEF..."
+
+// Toggle on (Some) with a numeric inner type
+"1000000000000"
+```
+
+The value shape depends entirely on the resolved inner component's output. The Option wrapper does not add any envelope -- it passes through the inner value as-is.

--- a/content/docs/components/struct-input.mdx
+++ b/content/docs/components/struct-input.mdx
@@ -1,0 +1,130 @@
+---
+title: Struct Input
+description: Composite field group for Substrate struct types with per-field validation
+---
+
+# Struct Input
+
+The Struct input renders a group of named fields inside a card, where each field has its own resolved sub-input component. Structs are Substrate's equivalent of named record types -- they appear in extrinsic parameters for multi-field configurations like `IdentityInfo`, `ProxyDefinition`, and any call argument that the metadata defines as a `Struct` TypeDef.
+
+## Supported Types
+
+The Struct component sits at **priority 35** in the registry with no explicit type name patterns. Instead, it is resolved through the **TypeDef fallback** mechanism: when no higher-priority pattern matches and the chain metadata reports the type's `TypeDef` as `"Struct"`, `findComponent` returns the Struct component.
+
+This means the Struct component handles any type that the metadata declares as a struct, regardless of its name.
+
+## Props
+
+The component extends `ParamInputProps` with a required `fields` prop:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used as a prefix for child field IDs |
+| `label` | `string` | No | Display label shown above the card |
+| `description` | `string` | No | Help text shown below the card |
+| `typeName` | `string` | No | The SCALE type name |
+| `isDisabled` | `boolean` | No | Disables all child inputs |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client for metadata |
+| `typeId` | `number` | No | Metadata type ID for this struct |
+| `value` | `any` | No | Externally controlled value |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the struct record |
+| `fields` | `StructField[]` | Yes | Field definitions including pre-resolved components |
+
+### StructField Interface
+
+```ts
+interface StructField {
+  name: string;
+  label: string;
+  description?: string;
+  typeName?: string;
+  component: React.ReactNode;
+  required?: boolean;
+}
+```
+
+The `fields` array is injected by the extrinsic builder at render time after resolving each field's component from the chain metadata.
+
+## Features
+
+- **Card layout**: Fields render inside a `Card` component with consistent spacing and visual grouping.
+- **Per-field components**: Each field receives its own pre-resolved React component, which is cloned with the correct `name`, `label`, `isDisabled`, and `onChange` props.
+- **Type badge**: Each field label shows a small code badge with its SCALE type name for clarity.
+- **Required field validation**: Uses `validateStructFields` to check that all required fields have values, displaying a validation error when they are missing.
+- **Composable**: Struct fields can themselves be enums, vectors, or other structs, enabling deeply nested composite types.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// Struct is resolved via the TypeDef fallback, not by type name patterns.
+// When the metadata reports typeId 50 as a Struct:
+const resolved = findComponent("SomeCustomStruct", 50, client);
+// Returns { component: Struct, schema, typeId: 50 }
+```
+
+## Usage
+
+The Struct component is rendered by the extrinsic builder when a parameter's metadata type is a struct. Direct usage requires pre-resolved field components:
+
+```tsx
+import { Struct } from "@/components/params/inputs/struct";
+
+<Struct
+  name="identity"
+  label="Identity Info"
+  client={client}
+  typeId={50}
+  fields={[
+    {
+      name: "display",
+      label: "Display Name",
+      typeName: "Data",
+      component: <TextInput />,
+      required: true,
+    },
+    {
+      name: "email",
+      label: "Email",
+      typeName: "Data",
+      component: <TextInput />,
+    },
+  ]}
+  onChange={(val) => console.log("Struct:", val)}
+/>
+```
+
+## Validation
+
+The component uses a Zod schema that expects a record of string keys to any values:
+
+```ts
+const schema = z.record(z.string(), z.any());
+```
+
+Additionally, `validateStructFields` checks that all fields marked as `required` are present and non-undefined in the values record.
+
+## Value Format
+
+The `onChange` callback receives a **flat record** mapping field names to their values:
+
+```ts
+// Example: IdentityInfo struct
+{
+  display: "Alice",
+  email: "alice@example.com",
+  web: undefined
+}
+
+// Example: ProxyDefinition struct
+{
+  delegate: "5GrwvaEF...",
+  proxyType: { type: "Any" },
+  delay: "0"
+}
+```
+
+Each key corresponds to a `StructField.name`, and the value is whatever the field's resolved component emits. Fields that have not been filled in will have `undefined` values.

--- a/content/docs/components/tuple-input.mdx
+++ b/content/docs/components/tuple-input.mdx
@@ -1,0 +1,88 @@
+---
+title: Tuple Input
+description: Positional element group for Substrate tuple types with auto-resolved sub-inputs
+---
+
+# Tuple Input
+
+The Tuple input handles Substrate tuple types by rendering a fixed-length group of positional sub-inputs inside a card. Each element's type is resolved from the chain metadata and rendered with the appropriate component. Tuples appear in Substrate when a parameter combines multiple values without named fields -- for example `(AccountId, Balance)` or `(u32, u32)`.
+
+## Supported Type Names
+
+The Tuple component matches the following type name patterns at **priority 38**:
+
+- Any type name matching `/^\(/` (e.g. `(AccountId32, u128)`, `(u32, u32)`)
+- Any type name matching `/^Tuple/`
+
+## Props
+
+The component extends `ParamInputProps` with a required `typeId`:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used as a prefix for element IDs |
+| `label` | `string` | No | Display label shown above the card |
+| `description` | `string` | No | Help text shown below the card |
+| `typeName` | `string` | No | The SCALE type name (e.g. `"(AccountId32, u128)"`) |
+| `isDisabled` | `boolean` | No | Disables all element inputs |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client for resolving element types |
+| `typeId` | `number` | Yes | Metadata type ID used to look up the tuple's element types |
+| `value` | `any` | No | Externally controlled value |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the tuple array |
+
+## Features
+
+- **Auto-resolves element types**: Reads the tuple's field type IDs from the chain metadata (`typeDef.type === "Tuple"`) and resolves each element to the correct input component via `findComponent`.
+- **Indexed labels**: Each element is labeled with a short type name and its positional index (e.g. `AccountId [0]`, `Balance [1]`).
+- **Card layout**: Elements render inside a `Card` with consistent spacing.
+- **Fallback message**: If the tuple structure cannot be resolved from metadata, a fallback message is displayed instead of broken inputs.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// Matched by the /^\(/ or /^Tuple/ patterns at priority 38
+findComponent("(AccountId32, u128)", 25, client);
+findComponent("(u32, u32, u32)", 30, client);
+```
+
+## Usage
+
+The Tuple component is rendered by the extrinsic builder when a parameter type starts with `(` or `Tuple`. Direct usage:
+
+```tsx
+import { Tuple } from "@/components/params/inputs/tuple";
+
+<Tuple
+  name="range"
+  label="Block Range"
+  client={client}
+  typeId={25}
+  onChange={(val) => console.log("Tuple:", val)}
+/>
+```
+
+## Validation
+
+The component uses a Zod schema that expects an array of any values:
+
+```ts
+const schema = z.array(z.any());
+```
+
+## Value Format
+
+The `onChange` callback receives an **array** where each element corresponds to a positional field in the tuple:
+
+```ts
+// (AccountId32, u128) tuple
+["5GrwvaEF...", "1000000000000"]
+
+// (u32, u32, u32) tuple
+["100", "200", "300"]
+```
+
+The array length always matches the number of fields in the tuple definition. Each element's value type depends on the resolved sub-component's output.

--- a/content/docs/components/vector-fixed-input.mdx
+++ b/content/docs/components/vector-fixed-input.mdx
@@ -1,0 +1,98 @@
+---
+title: VectorFixed Input
+description: Fixed-length array input for Substrate [T; N] types with specialized byte array handling
+---
+
+# VectorFixed Input
+
+The VectorFixed input handles Substrate fixed-length array types (`[T; N]`) with two rendering strategies: byte arrays (`[u8; N]`) get a specialized hex/base64 text input, while other element types render N individual sub-inputs. Fixed-length arrays appear in Substrate for cryptographic data (signatures, public keys), fixed-size identifiers, and any parameter with a compile-time known length.
+
+## Supported Type Names
+
+The VectorFixed component matches the following type name pattern at **priority 43**:
+
+- Any type name matching `/^\[.+;\s*\d+\]$/` (e.g. `[u8; 32]`, `[u8; 64]`, `[AccountId32; 3]`)
+
+## Props
+
+The component extends `ParamInputProps` with a required `typeId`:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used for the HTML `id` and form state |
+| `label` | `string` | No | Display label shown above the input |
+| `description` | `string` | No | Help text shown below the input |
+| `typeName` | `string` | No | The SCALE type name (e.g. `"[u8; 32]"`) |
+| `isDisabled` | `boolean` | No | Disables the input |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client for resolving element types |
+| `typeId` | `number` | Yes | Metadata type ID used to look up the `SizedVec` structure |
+| `value` | `any` | No | Externally controlled value (e.g. from hex decode) |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the array value |
+
+## Features
+
+- **Byte array mode** (`[u8; N]`): Renders a single text input with a hex/base64 mode toggle. Validates that the decoded byte length matches the expected `N`.
+- **Hex input**: Accepts `0x`-prefixed hex strings; auto-prepends `0x` if missing. Shows the expected hex character count as a placeholder.
+- **Base64 input**: Accepts standard Base64 strings. Automatically syncs with the hex representation.
+- **Per-element mode** (non-u8 types): Renders `N` individual sub-inputs, each resolved via `findComponent` for the inner type.
+- **Registry fallback**: Parses the length and inner type from the `typeName` string first, then falls back to the `SizedVec` typeDef in the chain metadata.
+- **External value sync**: Accepts external byte arrays (e.g. from hex decoding) and populates both hex and base64 fields.
+- **Length validation**: Byte length mismatches produce a clear error message showing expected vs. actual length.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// Matched by /^\[.+;\s*\d+\]$/ at priority 43
+findComponent("[u8; 32]", 8, client);
+findComponent("[u8; 64]", 9, client);
+findComponent("[AccountId32; 3]", 14, client);
+```
+
+## Usage
+
+The VectorFixed component is rendered by the extrinsic builder when a parameter type matches the fixed array syntax. Direct usage:
+
+```tsx
+import { VectorFixed } from "@/components/params/inputs/vector-fixed";
+
+<VectorFixed
+  name="signature"
+  label="Signature"
+  description="Ed25519 signature bytes"
+  client={client}
+  typeId={8}
+  typeName="[u8; 64]"
+  onChange={(val) => console.log("Bytes:", val)}
+/>
+```
+
+## Validation
+
+The component uses a Zod schema that expects an array of any values:
+
+```ts
+const schema = z.array(z.any());
+```
+
+For byte arrays, additional runtime validation ensures the decoded byte length matches `N`. Invalid hex or base64 strings produce specific error messages.
+
+## Value Format
+
+The `onChange` callback receives an **array of values** whose shape depends on the inner type:
+
+```ts
+// [u8; 32] — byte array as number array
+[0, 1, 2, ..., 31]
+
+// [u8; 64] — 64-byte signature
+[72, 101, 108, ..., 0]
+
+// [AccountId32; 3] — fixed array of accounts
+["5GrwvaEF...", "5FHneW46...", "5DAAnrj7..."]
+```
+
+For `[u8; N]` types, the value is always a `number[]` of length `N` derived from the hex or base64 input. For other inner types, each element is the output of its resolved sub-component.

--- a/content/docs/components/vector-input.mdx
+++ b/content/docs/components/vector-input.mdx
@@ -1,0 +1,107 @@
+---
+title: Vector Input
+description: Dynamic-length list input for Substrate Vec<T> types with bulk entry support
+---
+
+# Vector Input
+
+The Vector input handles Substrate `Vec<T>` and `BoundedVec<T>` types by rendering a dynamic list of sub-inputs where items can be added, removed, and reordered. It supports both a form mode with individual item inputs and a bulk mode for pasting JSON arrays or line-separated values. Vectors are used extensively in Substrate for batch operations, multi-sig signatories, validator lists, and any parameter that accepts a variable-length collection.
+
+## Supported Type Names
+
+The Vector component matches the following type name patterns at **priority 40**:
+
+- Any type name matching `/^Vec</` (e.g. `Vec<AccountId32>`, `Vec<u8>`)
+- Any type name matching `/^BoundedVec</` (e.g. `BoundedVec<u8, MaxLen>`)
+
+Note: `Vec<u8>` is handled by the higher-priority Bytes component (priority 75) before reaching Vector.
+
+## Props
+
+The component extends `ParamInputProps` with additional collection props:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used as a prefix for item IDs |
+| `label` | `string` | No | Display label shown above the list |
+| `description` | `string` | No | Help text shown below the list |
+| `typeName` | `string` | No | The SCALE type name (e.g. `"Vec<AccountId32>"`) |
+| `isDisabled` | `boolean` | No | Disables all controls and item inputs |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client for resolving the element type |
+| `typeId` | `number` | No | Metadata type ID for the vector type |
+| `value` | `any` | No | Externally controlled value (e.g. from hex decode) |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the array of defined values |
+| `children` | `React.ReactNode` | No | Legacy: explicit child component to clone per item |
+| `minItems` | `number` | No | Minimum number of items (default: `0`) |
+| `maxItems` | `number` | No | Maximum number of items (no limit by default) |
+
+## Features
+
+- **Auto-resolves element type**: Reads the vector's `Sequence` typeDef from metadata to find the element type, then uses `findComponent` to render the correct input for each item.
+- **Add/Remove items**: An "Add" button appends new items; each item has a remove button (respecting `minItems`).
+- **Reorder items**: Up/down chevron buttons let users reorder items within the list.
+- **Bulk entry mode**: A toggle switches between form mode (individual inputs) and bulk mode (a textarea accepting JSON arrays or line-separated values).
+- **Duplicate detection**: Warns when duplicate values are detected in form mode.
+- **Constraint display**: Shows min/max item constraints when configured.
+- **External value sync**: Accepts external arrays (e.g. from hex decoding) and syncs them into the form state.
+- **Validation**: Uses `validateVectorConstraints` to check min/max item counts.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// Matched by /^Vec</ or /^BoundedVec</ at priority 40
+findComponent("Vec<AccountId32>", 12, client);
+findComponent("BoundedVec<u8, MaxLen>", 18, client);
+```
+
+## Usage
+
+The Vector component is rendered by the extrinsic builder when a parameter type starts with `Vec<` or `BoundedVec<`. Direct usage:
+
+```tsx
+import { Vector } from "@/components/params/inputs/vector";
+
+<Vector
+  name="signatories"
+  label="Signatories"
+  description="List of signatory accounts"
+  client={client}
+  typeId={12}
+  minItems={2}
+  onChange={(val) => console.log("Items:", val)}
+/>
+```
+
+## Validation
+
+The component uses a Zod schema that expects an array of any values:
+
+```ts
+const schema = z.array(z.any());
+```
+
+Additionally, `validateVectorConstraints` checks that the number of defined items falls within the configured `minItems` and `maxItems` bounds.
+
+## Value Format
+
+The `onChange` callback receives an **array of defined values** (items that are `undefined` are filtered out):
+
+```ts
+// Vec<AccountId32>
+["5GrwvaEF...", "5FHneW46..."]
+
+// Vec<u128>
+["1000000000000", "2000000000000"]
+
+// Vec with complex inner types
+[
+  { type: "Staked" },
+  { type: "Account", value: "5GrwvaEF..." }
+]
+```
+
+The value shape of each element depends on the resolved inner component's output.


### PR DESCRIPTION
## Summary
- Added documentation pages for 8 composite/collection input components
- Each page follows the established pattern (frontmatter, intro, supported types, props table, features, type resolution, usage, validation, value format)

### Pages created
- **option-input.mdx** — Toggle-based wrapper for `Option<T>` types (priority 45)
- **struct-input.mdx** — Named field group for Struct TypeDef fallback (priority 35)
- **tuple-input.mdx** — Positional element group for `(T1, T2, ...)` types (priority 38)
- **vector-input.mdx** — Dynamic list for `Vec<T>` / `BoundedVec<T>` types (priority 40)
- **vector-fixed-input.mdx** — Fixed-length array for `[T; N]` types with hex/base64 byte mode (priority 43)
- **btree-map-input.mdx** — Key-value pair editor for `BTreeMap<K, V>` types (priority 42)
- **btree-set-input.mdx** — Unique-value collection for `BTreeSet<T>` types (priority 41)
- **call-input.mdx** — Nested extrinsic builder for `RuntimeCall` parameters (priority 70)