### PR TITLE
Add docs for primitive input components

### DIFF
--- a/content/docs/components/amount-input.mdx
+++ b/content/docs/components/amount-input.mdx
@@ -1,0 +1,92 @@
+---
+title: Amount Input
+description: Numeric input for integer types with range validation and hex mode
+---
+
+# Amount Input
+
+The Amount input provides a numeric field for entering integer values such as `u32`, `u64`, `u128`, and their signed and compact variants. It displays the valid range for the type, supports decimal and hexadecimal input modes for large integers, and offers denomination support for balance-like compact types like `Compact<u128>`.
+
+## Supported Type Names
+
+The Amount component matches the following type names at **priority 90**:
+
+- `Compact<u128>`
+- `Compact<u64>`
+- `Compact<u32>`
+- `u128`, `u64`, `u32`, `u16`, `u8`
+- `i128`, `i64`, `i32`, `i16`, `i8`
+- Any type name matching `/Compact</`
+
+Note: `Compact<Balance>` and `Compact<BalanceOf>` are caught by the Balance component at priority 95, not by Amount.
+
+## Props
+
+The component accepts the standard `ParamInputProps` interface plus an optional `typeName`:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used for the HTML `id` and form state |
+| `label` | `string` | No | Display label shown above the input |
+| `description` | `string` | No | Help text shown below the input |
+| `typeName` | `string` | No | The SCALE type name (e.g. `"u64"`, `"Compact<u128>"`). Determines range, denomination, and hex toggle behavior |
+| `isDisabled` | `boolean` | No | Disables the input when true |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client for chain metadata |
+| `typeId` | `number` | No | Metadata type ID for this parameter |
+| `value` | `any` | No | Externally controlled value (e.g. from hex decode) |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the numeric value as a string |
+
+## Features
+
+- **Automatic range display**: Shows the valid range beneath the input based on the integer type. For example, `u8` shows `0 -- 255` and `i16` shows `-32768 -- 32767`.
+- **Hex/Decimal toggle**: For large integer types (`u128`, `u256`, `i128`, `i256`, `Compact<u128>`), a mode toggle lets the user switch between decimal and hexadecimal input. Converting between modes preserves the value.
+- **Denomination support**: For `Compact<u128>` and `u128`, the input shows a denomination selector (e.g. DOT, mDOT, planck) similar to the Balance component, using the chain's native token metadata.
+- **Range validation**: Values outside the type's min/max range produce an inline error. For unsigned types the minimum is 0; for signed types it is the negative two's complement bound.
+- **Paste formatting**: Strips commas, spaces, and other numeric formatting characters from pasted values so users can paste amounts from block explorers.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// All of these resolve to the Amount component
+findComponent("u32", typeId, client);
+findComponent("u128", typeId, client);
+findComponent("i64", typeId, client);
+findComponent("Compact<u64>", typeId, client);
+```
+
+## Usage
+
+The Amount component is rendered by the extrinsic builder when a parameter resolves to a numeric integer type. Direct usage:
+
+```tsx
+import { Amount } from "@/components/params/inputs/amount";
+
+<Amount
+  name="weight"
+  label="Weight"
+  description="The dispatch weight"
+  typeName="u64"
+  client={client}
+  typeId={8}
+  isRequired
+  onChange={(value) => console.log("Value:", value)}
+/>
+```
+
+## Validation
+
+The component uses a Zod schema that checks for a non-negative number:
+
+```ts
+const schema = z.number().min(0);
+```
+
+Additional runtime range validation is performed against the integer type bounds (e.g. `u8` rejects values above 255).
+
+## Value Format
+
+The `onChange` callback receives a **string** representing the integer value in decimal (e.g. `"42"`, `"1000000000000"`). For denominated types, the value is emitted in planck. If the input is cleared, `undefined` is emitted.

--- a/content/docs/components/bool-input.mdx
+++ b/content/docs/components/bool-input.mdx
@@ -1,0 +1,77 @@
+---
+title: Bool Input
+description: Toggle switch for boolean parameters
+---
+
+# Bool Input
+
+The Bool input renders a toggle switch for Substrate boolean parameters. It provides a simple on/off control that maps directly to SCALE `bool` encoding.
+
+## Supported Type Names
+
+The Boolean component matches the following type name at **priority 85**:
+
+- `bool`
+
+## Props
+
+The component accepts the standard `ParamInputProps` interface:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used for the HTML `id` and form state |
+| `label` | `string` | No | Display label shown next to the switch |
+| `description` | `string` | No | Help text shown below the label |
+| `typeName` | `string` | No | The SCALE type name (`"bool"`) |
+| `isDisabled` | `boolean` | No | Disables the switch when true |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client |
+| `typeId` | `number` | No | Metadata type ID for this parameter |
+| `value` | `any` | No | Externally controlled value -- accepts `true`, `false`, `"true"`, or `"false"` |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the boolean value |
+
+## Features
+
+- **Toggle switch UI**: Uses a shadcn/ui `Switch` component instead of a checkbox, providing a clear visual on/off state.
+- **Horizontal layout**: The label and description are placed on the left, the switch on the right, in a single row for compact display.
+- **String coercion**: Accepts both boolean `true`/`false` and string `"true"`/`"false"` as external values, handling the common case where decoded hex values arrive as strings.
+- **Accessible**: The switch is linked to the label via `aria-label` for screen reader compatibility.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// Resolves to the Boolean component
+findComponent("bool", typeId, client);
+```
+
+## Usage
+
+The Bool component is rendered by the extrinsic builder when a parameter resolves to a `bool` type. Direct usage:
+
+```tsx
+import { Boolean } from "@/components/params/inputs/boolean";
+
+<Boolean
+  name="approve"
+  label="Approve"
+  description="Whether to approve the proposal"
+  client={client}
+  typeId={1}
+  onChange={(value) => console.log("Checked:", value)}
+/>
+```
+
+## Validation
+
+The component uses a Zod schema that validates a boolean value:
+
+```ts
+const schema = z.boolean();
+```
+
+## Value Format
+
+The `onChange` callback receives a **boolean** (`true` or `false`). The initial state is unchecked (`false`). If the switch is toggled, the new boolean value is emitted immediately.

--- a/content/docs/components/bytes-input.mdx
+++ b/content/docs/components/bytes-input.mdx
@@ -1,0 +1,92 @@
+---
+title: Bytes Input
+description: Multi-mode byte array input with hex, text, JSON, Base64, and file upload
+---
+
+# Bytes Input
+
+The Bytes input provides a multi-mode editor for entering raw byte data. It supports five input modes -- hex, plain text, JSON, Base64, and file upload -- and automatically converts between them. All modes emit the same hex-encoded byte string to the parent form.
+
+## Supported Type Names
+
+The Bytes component matches the following type names at **priority 75**:
+
+- `Bytes`
+- `Vec<u8>`
+- Any type name matching `/Bytes/`
+
+## Props
+
+The component accepts the standard `ParamInputProps` interface:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used for the HTML `id` and form state |
+| `label` | `string` | No | Display label shown above the input |
+| `description` | `string` | No | Help text shown below the input |
+| `typeName` | `string` | No | The SCALE type name (e.g. `"Bytes"`, `"Vec<u8>"`) |
+| `isDisabled` | `boolean` | No | Disables the input when true |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client |
+| `typeId` | `number` | No | Metadata type ID for this parameter |
+| `value` | `any` | No | Externally controlled hex value (e.g. from hex decode) |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the hex-encoded bytes string |
+
+## Features
+
+- **Five input modes**: A mode toggle at the top switches between Hex, Text, JSON, B64 (Base64), and File modes. Each mode converts the input to hex internally.
+- **Hex mode**: Direct hex input with `0x` prefix. Auto-prefixes `0x` if omitted.
+- **Text mode**: A textarea that encodes the entered UTF-8 text to hex bytes using `TextEncoder`.
+- **JSON mode**: A textarea that validates JSON syntax before encoding. Shows an inline error for invalid JSON. Pretty-prints existing data when switching to JSON mode.
+- **Base64 mode**: Accepts a Base64-encoded string and decodes it to hex bytes. Shows an inline error for invalid Base64.
+- **File upload mode**: A file picker that reads the selected file as an `ArrayBuffer` and converts it to hex. Displays the file name and a truncated hex preview.
+- **Cross-mode sync**: Changing the value in one mode updates the internal hex representation, and switching modes reflects the current data in the new format when possible.
+- **Byte count display**: Shows the byte count of the current data alongside the description.
+- **External value sync**: When an external hex value is set (e.g. from decoding), the component attempts to decode it as UTF-8 text, JSON, and Base64 to pre-populate all modes.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// All of these resolve to the Bytes component
+findComponent("Bytes", typeId, client);
+findComponent("Vec<u8>", typeId, client);
+```
+
+## Usage
+
+The Bytes component is rendered by the extrinsic builder when a parameter resolves to a byte array type. Direct usage:
+
+```tsx
+import { Bytes } from "@/components/params/inputs/bytes";
+
+<Bytes
+  name="data"
+  label="Data"
+  description="The raw byte payload"
+  client={client}
+  typeId={14}
+  isRequired
+  onChange={(hex) => console.log("Hex bytes:", hex)}
+/>
+```
+
+## Validation
+
+The component uses a Zod schema that validates the value is a valid hex string with an even number of characters:
+
+```ts
+const schema = z.string().refine(
+  (value) => {
+    if (value === "") return true;
+    return isHex(value) && value.length % 2 === 0;
+  },
+  { message: "Invalid bytes (must be hex string with 0x prefix and even length)" }
+);
+```
+
+## Value Format
+
+The `onChange` callback receives a **string** -- a `0x`-prefixed hex string representing the byte data (e.g. `"0x48656c6c6f"` for the text "Hello"). If the input is cleared, `undefined` is emitted.

--- a/content/docs/components/hash-input.mdx
+++ b/content/docs/components/hash-input.mdx
@@ -1,0 +1,109 @@
+---
+title: Hash Input
+description: Fixed-length hex hash input for H160, H256, and H512 types
+---
+
+# Hash Input
+
+The Hash input provides a hex string field for fixed-length hash types. Three variants are exported -- `Hash160`, `Hash256`, and `Hash512` -- each validating against the expected byte length. A live validation icon shows whether the current value matches the required format.
+
+## Supported Type Names
+
+The three Hash variants are registered at different priorities to ensure correct matching:
+
+**Hash160** -- priority **82**:
+- `H160`
+- Any type name matching `/^H160$/`
+
+**Hash256** -- priority **80**:
+- `H256`
+- `Hash`
+- Any type name matching `/H256/` or `/Hash/`
+
+**Hash512** -- priority **78**:
+- `H512`
+- Any type name matching `/^H512$/`
+
+## Props
+
+All three variants accept the standard `ParamInputProps` interface. The internal `Hash` component also receives a `hashType` prop, but this is set automatically by each exported variant:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used for the HTML `id` and form state |
+| `label` | `string` | No | Display label shown above the input |
+| `description` | `string` | No | Help text shown below the input |
+| `typeName` | `string` | No | The SCALE type name (e.g. `"H256"`) |
+| `isDisabled` | `boolean` | No | Disables the input when true |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client |
+| `typeId` | `number` | No | Metadata type ID for this parameter |
+| `value` | `any` | No | Externally controlled hex value (e.g. from hex decode) |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the hex hash string |
+
+## Features
+
+- **Fixed-length validation**: Each variant enforces the correct hex character count -- 40 for H160 (20 bytes), 64 for H256 (32 bytes), 128 for H512 (64 bytes).
+- **Live validation icon**: A green checkmark or red X icon appears in the input suffix to indicate whether the current value is a valid hash of the expected length.
+- **Auto `0x` prefix on paste**: When pasting a hex string without the `0x` prefix, the component automatically prepends it using the `autoPrefix0x` utility.
+- **Lowercase normalization**: Input is automatically lowercased for consistent hex formatting.
+- **Contextual placeholder**: Each variant shows a placeholder of the correct length so the user can see the expected format at a glance.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// Each hash type resolves to its specific variant
+findComponent("H160", typeId, client);  // -> Hash160
+findComponent("H256", typeId, client);  // -> Hash256
+findComponent("Hash", typeId, client);  // -> Hash256
+findComponent("H512", typeId, client);  // -> Hash512
+```
+
+## Usage
+
+The Hash components are rendered by the extrinsic builder when a parameter resolves to a hash type. Direct usage:
+
+```tsx
+import { Hash256 } from "@/components/params/inputs/hash";
+
+<Hash256
+  name="codeHash"
+  label="Code Hash"
+  description="The hash of the contract code"
+  client={client}
+  typeId={11}
+  isRequired
+  onChange={(hash) => console.log("Hash:", hash)}
+/>
+```
+
+## Validation
+
+Each variant uses a Zod schema that validates the hex string length:
+
+```ts
+// H160: 40 hex characters (20 bytes)
+const hash160Schema = z.string().refine(
+  (value) => /^0x[0-9a-fA-F]{40}$/.test(value),
+  { message: "Invalid H160 hash (should be 40 hex characters with 0x prefix)" }
+);
+
+// H256: 64 hex characters (32 bytes)
+const hash256Schema = z.string().refine(
+  (value) => /^0x[0-9a-fA-F]{64}$/.test(value),
+  { message: "Invalid H256 hash (should be 64 hex characters with 0x prefix)" }
+);
+
+// H512: 128 hex characters (64 bytes)
+const hash512Schema = z.string().refine(
+  (value) => /^0x[0-9a-fA-F]{128}$/.test(value),
+  { message: "Invalid H512 hash (should be 128 hex characters with 0x prefix)" }
+);
+```
+
+## Value Format
+
+The `onChange` callback receives a **string** -- a `0x`-prefixed lowercase hex string of the appropriate length. If the input is cleared, `undefined` is emitted.

--- a/content/docs/components/key-value-input.mdx
+++ b/content/docs/components/key-value-input.mdx
@@ -1,0 +1,86 @@
+---
+title: KeyValue Input
+description: Two-field key/value pair input with automatic type resolution
+---
+
+# KeyValue Input
+
+The KeyValue input renders a side-by-side key and value pair within a card. It resolves the types of both fields from chain metadata when available, falling back to plain text inputs. This component is used for `KeyValue` storage items and similar two-field structures.
+
+## Supported Type Names
+
+The KeyValue component matches the following type names at **priority 50**:
+
+- `KeyValue`
+- Any type name matching `/KeyValue/`
+
+## Props
+
+The component accepts the standard `ParamInputProps` interface plus optional component overrides:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used for the HTML `id` and form state |
+| `label` | `string` | No | Display label shown above the card |
+| `description` | `string` | No | Help text shown below the card |
+| `typeName` | `string` | No | The SCALE type name (e.g. `"KeyValue"`) |
+| `isDisabled` | `boolean` | No | Disables both key and value inputs when true |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client for type resolution |
+| `typeId` | `number` | No | Metadata type ID used to resolve inner key/value types |
+| `value` | `any` | No | Externally controlled value |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the `{ key, value }` object |
+| `keyComponent` | `React.ReactNode` | No | Custom React element to use for the key field |
+| `valueComponent` | `React.ReactNode` | No | Custom React element to use for the value field |
+
+## Features
+
+- **Automatic type resolution**: When a `typeId` is provided and the metadata describes a Tuple with two fields, the component resolves each field's type through `findComponent` and renders the appropriate typed input (e.g. an Account input for an `AccountId` key, an Amount input for a `u64` value).
+- **Custom component injection**: The `keyComponent` and `valueComponent` props allow parent components to override the default type resolution with specific React elements. The KeyValue component clones these elements with the appropriate `name`, `label`, `isDisabled`, `isRequired`, and `onChange` props.
+- **Card layout**: The key and value fields are displayed side by side in a two-column grid within a card, visually grouping them as a pair.
+- **Fallback to text**: When no metadata is available and no custom components are provided, both fields render as plain text inputs.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// Resolves to the KeyValue component
+findComponent("KeyValue", typeId, client);
+```
+
+## Usage
+
+The KeyValue component is rendered by the extrinsic builder when a parameter resolves to a `KeyValue` type. Direct usage:
+
+```tsx
+import { KeyValue } from "@/components/params/inputs/key-value";
+
+<KeyValue
+  name="entry"
+  label="Storage Entry"
+  description="A key-value storage pair"
+  client={client}
+  typeId={20}
+  isRequired
+  onChange={(pair) => console.log("Key-Value:", pair)}
+/>
+```
+
+## Validation
+
+The component uses a Zod schema that validates an object with `key` and `value` fields:
+
+```ts
+const schema = z.object({
+  key: z.any(),
+  value: z.any(),
+});
+```
+
+Inner field validation is delegated to the resolved child components.
+
+## Value Format
+
+The `onChange` callback receives an **object** with `key` and `value` properties (e.g. `{ key: "0xabc", value: "42" }`). Both fields must have a value before the object is emitted. If either field is cleared, `undefined` is emitted.

--- a/content/docs/components/moment-input.mdx
+++ b/content/docs/components/moment-input.mdx
@@ -1,0 +1,79 @@
+---
+title: Moment Input
+description: Date-time picker with quick presets for timestamp parameters
+---
+
+# Moment Input
+
+The Moment input provides a date-time picker for Substrate `Moment` parameters. It uses the browser's native `datetime-local` input and offers quick preset buttons for common time offsets. The selected date-time is converted to a Unix timestamp in milliseconds.
+
+## Supported Type Names
+
+The Moment component matches the following type names at **priority 65**:
+
+- `Moment`
+- Any type name matching `/Moment/`
+
+## Props
+
+The component accepts the standard `ParamInputProps` interface:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used for the HTML `id` and form state |
+| `label` | `string` | No | Display label shown above the input |
+| `description` | `string` | No | Help text shown below the input |
+| `typeName` | `string` | No | The SCALE type name (`"Moment"`) |
+| `isDisabled` | `boolean` | No | Disables the input and preset buttons when true |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client |
+| `typeId` | `number` | No | Metadata type ID for this parameter |
+| `value` | `any` | No | Externally controlled timestamp in milliseconds (e.g. from hex decode) |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the timestamp as a string |
+
+## Features
+
+- **Native date-time picker**: Uses the browser's `datetime-local` input type for a familiar date and time selection interface.
+- **Quick preset buttons**: Five preset buttons for common time values -- "Now", "+1h", "+6h", "+24h", and "+7d" -- that calculate timestamps relative to the current time.
+- **Timezone display**: Shows the user's local timezone (e.g. "America/New_York") beneath the input so there is no ambiguity about the time reference.
+- **External value sync**: When an external timestamp is set (e.g. from hex decoding), it is converted to a `datetime-local` string and displayed in the picker.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// Resolves to the Moment component
+findComponent("Moment", typeId, client);
+```
+
+## Usage
+
+The Moment component is rendered by the extrinsic builder when a parameter resolves to a `Moment` type. Direct usage:
+
+```tsx
+import { Moment } from "@/components/params/inputs/moment";
+
+<Moment
+  name="when"
+  label="Schedule Time"
+  description="The time at which to execute"
+  client={client}
+  typeId={4}
+  isRequired
+  onChange={(timestamp) => console.log("Timestamp:", timestamp)}
+/>
+```
+
+## Validation
+
+The component uses a Zod schema that checks for a non-negative integer:
+
+```ts
+const schema = z.number().int().min(0);
+```
+
+## Value Format
+
+The `onChange` callback receives a **string** representing the Unix timestamp in milliseconds (e.g. `"1700000000000"`). This format is compatible with BigInt conversion for SCALE encoding. If the input is cleared, `undefined` is emitted.

--- a/content/docs/components/text-input.mdx
+++ b/content/docs/components/text-input.mdx
@@ -1,0 +1,76 @@
+---
+title: Text Input
+description: Generic string input and fallback for unknown types
+---
+
+# Text Input
+
+The Text input is a plain string field that serves as the fallback component for any parameter type that does not match a more specific input in the registry. It accepts arbitrary text and emits it as a raw string.
+
+## Supported Type Names
+
+The Text component is not registered with explicit patterns in the input map. Instead, it is the **fallback** returned by `findComponent` when no other component matches the given type name. Any type that does not match Account, Balance, Amount, Bool, Hash, Bytes, Call, Moment, Vote, VoteThreshold, KeyValue, Option, Vector, Tuple, Struct, or Enum will resolve to Text.
+
+## Props
+
+The component accepts the standard `ParamInputProps` interface:
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Field identifier used for the HTML `id` and form state |
+| `label` | `string` | No | Display label shown above the input |
+| `description` | `string` | No | Help text shown below the input |
+| `typeName` | `string` | No | The SCALE type name |
+| `isDisabled` | `boolean` | No | Disables the input when true |
+| `isRequired` | `boolean` | No | Shows a red asterisk next to the label |
+| `error` | `string` | No | Validation error message to display |
+| `client` | `DedotClient<PolkadotApi>` | Yes | Connected Dedot client |
+| `typeId` | `number` | No | Metadata type ID for this parameter |
+| `value` | `any` | No | Externally controlled value (e.g. from hex decode) -- converted to string via `String()` |
+| `onChange` | `(value: unknown) => void` | No | Callback fired with the string value |
+
+## Features
+
+- **Universal fallback**: Any unrecognized type name in the metadata resolves to this component, ensuring every parameter has an input.
+- **External value sync**: When an external value is set (e.g. from hex decoding), it is coerced to a string via `String()` and displayed.
+- **Monospace font**: Uses a monospace font for consistency with other technical inputs.
+- **Error styling**: The input border turns red when a validation error is present.
+
+## Type Resolution
+
+```ts
+import { findComponent } from "@/lib/input-map";
+
+// Unknown types fall back to the Text component
+findComponent("SomeUnknownType", typeId, client);
+findComponent("Foo", typeId, client);
+```
+
+## Usage
+
+The Text component is rendered by the extrinsic builder as the default fallback. It can also be used directly:
+
+```tsx
+import { Text } from "@/components/params/inputs/text";
+
+<Text
+  name="remark"
+  label="Remark"
+  description="An arbitrary string"
+  client={client}
+  typeId={10}
+  onChange={(value) => console.log("Text:", value)}
+/>
+```
+
+## Validation
+
+The component uses a Zod schema that accepts any string:
+
+```ts
+const schema = z.string();
+```
+
+## Value Format
+
+The `onChange` callback receives a **string** -- the raw text entered by the user. If the input is cleared, an empty string `""` is emitted.


### PR DESCRIPTION
## Summary

Adds MDX documentation pages for 7 primitive/simple input components (9 components total, as Hash covers 3 variants):

- **amount-input.mdx** -- Numeric input for integer types (u8-u256, i8-i256, Compact variants) with range validation and hex/decimal toggle
- **bool-input.mdx** -- Toggle switch for `bool` parameters
- **text-input.mdx** -- Generic string input and fallback for unknown types
- **bytes-input.mdx** -- Multi-mode byte array input with hex, text, JSON, Base64, and file upload modes
- **hash-input.mdx** -- Fixed-length hex hash input covering H160 (priority 82), H256 (priority 80), and H512 (priority 78)
- **moment-input.mdx** -- Date-time picker with quick presets (Now, +1h, +6h, +24h, +7d)
- **key-value-input.mdx** -- Two-field key/value pair input with automatic type resolution from metadata

Each page follows the established documentation structure: frontmatter, intro, supported type names with priority, props table, features, type resolution examples, usage examples, validation schema, and value format.