### PR TITLE
Fix docs search, dark mode, and chain switching bugs

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,10 +1,26 @@
 import { source } from "@/lib/source";
+import { structure } from "fumadocs-core/mdx-plugins";
 import { createFromSource } from "fumadocs-core/search/server";
 
-export const { GET } = createFromSource(source, (page) => ({
-  title: page.data.title,
-  description: page.data.description,
-  url: page.url,
-  id: page.url,
-  structuredData: page.data.structuredData,
-}));
+// In fumadocs-core v15.x, the remarkStructure plugin does not implement
+// the `exportAs` option, so `page.data.structuredData` is always undefined.
+// This was fixed in fumadocs-core v16+. As a workaround, we read the raw
+// MDX content and compute structuredData at index time using `structure()`.
+export const { GET } = createFromSource(source, {
+  async buildIndex(page) {
+    let structuredData = page.data.structuredData;
+
+    if (!structuredData) {
+      const raw = await page.data.getText("raw");
+      structuredData = structure(raw);
+    }
+
+    return {
+      id: page.url,
+      title: page.data.title,
+      description: page.data.description,
+      url: page.url,
+      structuredData,
+    };
+  },
+});

--- a/components/params/inputs/struct.tsx
+++ b/components/params/inputs/struct.tsx
@@ -36,7 +36,7 @@ export function Struct({
 
   // Get list of required field names
   const requiredFieldNames = React.useMemo(() => {
-    return fields.filter((f) => f.required).map((f) => f.name);
+    return (fields || []).filter((f) => f.required).map((f) => f.name);
   }, [fields]);
 
   const validateAndEmit = (newValues: Record<string, any>) => {
@@ -64,7 +64,7 @@ export function Struct({
 
   // Render each field with its component
   const renderFields = () => {
-    return fields.map((field) => {
+    return (fields || []).map((field) => {
       if (React.isValidElement(field.component)) {
         return (
           <div key={field.name} className="mb-4 last:mb-0">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,10 +1,36 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "@luno-kit/ui/styles.css";
-@import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
 
-@plugin "@tailwindcss/typography";
+/* Map fumadocs variables to our shadcn theme so dark mode stays consistent.
+   Using @theme inline so var() references are preserved at runtime,
+   allowing .dark overrides of --foreground etc. to propagate correctly
+   into Fumadocs typography prose variables (--tw-prose-body, etc.). */
+@theme inline {
+  --color-fd-background: var(--background);
+  --color-fd-foreground: var(--foreground);
+  --color-fd-muted: var(--muted);
+  --color-fd-muted-foreground: var(--muted-foreground);
+  --color-fd-popover: var(--popover);
+  --color-fd-popover-foreground: var(--popover-foreground);
+  --color-fd-card: var(--card);
+  --color-fd-card-foreground: var(--card-foreground);
+  --color-fd-border: var(--border);
+  --color-fd-primary: var(--primary);
+  --color-fd-primary-foreground: var(--primary-foreground);
+  --color-fd-secondary: var(--secondary);
+  --color-fd-secondary-foreground: var(--secondary-foreground);
+  --color-fd-accent: var(--accent);
+  --color-fd-accent-foreground: var(--accent-foreground);
+  --color-fd-ring: var(--ring);
+}
+
+/* Note: Do NOT add @plugin "@tailwindcss/typography" here.
+   Fumadocs preset.css already includes its own typography plugin that
+   uses --color-fd-* variables for proper dark mode support. The standard
+   @tailwindcss/typography plugin would override those with pre-resolved
+   light-mode oklch values, breaking dark mode prose text. */
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
## Summary

- **Fix search API 500**: fumadocs-core v15 doesn't populate `page.data.structuredData` via the `remarkStructure` plugin. Added a custom `buildIndex` function that computes `structuredData` from raw MDX content using `structure()` at index time. Forward-compatible with v16+.

- **Fix dark mode text visibility**: Replaced `fumadocs-ui/css/neutral.css` import (which hardcodes dark mode fd-color variables) with `@theme inline` mappings from `--color-fd-*` to our shadcn theme variables. Removed duplicate `@tailwindcss/typography` plugin that was overriding Fumadocs' dark-mode-aware typography styles with pre-resolved light-mode oklch values.

- **Fix chain switching crash**: Deferred previous client disconnect with `setTimeout` so LunoKit's subscription cleanup effects can run before the WebSocket closes. Added null guard in Struct component for `fields` prop being undefined during chain transition.

## Test plan

- [x] Search: query "validator" returns rich results with headings, content, highlights
- [x] Dark mode: body text, headings, sidebar all readable on docs pages
- [x] Chain switching: Polkadot <-> Kusama works cleanly in both directions
- [x] Two-way hex editing: pasting real Subscan call data decodes correctly (tested Balances transfer_keep_alive, ConvictionVoting vote)
- [x] `yarn build` passes
- [x] `yarn test` — 259/259 tests pass