### PR TITLE
Add live preview demos to all component doc pages

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -8,7 +8,25 @@ import {
 import { notFound } from "next/navigation";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import { ComponentPreview } from "@/components/docs/component-preview";
-import { AccountDemo, BalanceDemo, EnumDemo } from "@/components/docs/demos";
+import {
+  AccountDemo,
+  BalanceDemo,
+  EnumDemo,
+  BoolDemo,
+  TextDemo,
+  HashDemo,
+  BytesDemo,
+  AmountDemo,
+  OptionDemo,
+  VectorDemo,
+  ValidatorSelectorDemo,
+  ValidatorMultiSelectorDemo,
+  PoolSelectorDemo,
+  EraSelectorDemo,
+  ReferendumSelectorDemo,
+  TrackSelectorDemo,
+  BountySelectorDemo,
+} from "@/components/docs/demos";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 export default async function Page(props: {
@@ -32,6 +50,20 @@ export default async function Page(props: {
             AccountDemo,
             BalanceDemo,
             EnumDemo,
+            BoolDemo,
+            TextDemo,
+            HashDemo,
+            BytesDemo,
+            AmountDemo,
+            OptionDemo,
+            VectorDemo,
+            ValidatorSelectorDemo,
+            ValidatorMultiSelectorDemo,
+            PoolSelectorDemo,
+            EraSelectorDemo,
+            ReferendumSelectorDemo,
+            TrackSelectorDemo,
+            BountySelectorDemo,
             Tab,
             Tabs,
           }}

--- a/components/docs/demos/balance-demo.tsx
+++ b/components/docs/demos/balance-demo.tsx
@@ -1,156 +1,17 @@
 "use client";
 
-import React, { useState, useCallback, useMemo } from "react";
-import { Label } from "@/components/ui/label";
-import { InputWithAddon } from "@/components/ui/input-with-addon";
-import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  getDenominations,
-  toPlanck,
-  fromPlanck,
-  type Denomination,
-} from "@/lib/denominations";
-
-const SYMBOL = "DOT";
-const DECIMALS = 10;
-const TRANSFERABLE = BigInt("150000000000"); // 15 DOT
-const EXISTENTIAL_DEPOSIT = BigInt("10000000000"); // 1 DOT
+import React from "react";
+import { Balance } from "@/components/params/inputs/balance";
 
 export function BalanceDemo() {
-  const denominations = useMemo(() => getDenominations(SYMBOL, DECIMALS), []);
-
-  const [displayValue, setDisplayValue] = useState("");
-  const [selectedDenomLabel, setSelectedDenomLabel] = useState(SYMBOL);
-
-  const selectedDenom: Denomination = useMemo(
-    () => denominations.find((d) => d.label === selectedDenomLabel) ?? denominations[0],
-    [selectedDenomLabel, denominations]
-  );
-
-  const isPlanck = selectedDenom.label === "planck";
-
-  const handleValueChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setDisplayValue(e.target.value);
-    },
-    []
-  );
-
-  const handleDenomChange = useCallback(
-    (newLabel: string) => {
-      const newDenom = denominations.find((d) => d.label === newLabel);
-      if (!newDenom) return;
-
-      if (displayValue.trim()) {
-        const currentPlanck = toPlanck(displayValue, selectedDenom);
-        if (currentPlanck) {
-          const converted = fromPlanck(currentPlanck, newDenom);
-          setDisplayValue(converted);
-        }
-      }
-
-      setSelectedDenomLabel(newLabel);
-    },
-    [denominations, displayValue, selectedDenom]
-  );
-
-  const handlePercentage = useCallback(
-    (percent: number) => {
-      let amount: bigint;
-      if (percent === 100) {
-        amount =
-          TRANSFERABLE > EXISTENTIAL_DEPOSIT
-            ? TRANSFERABLE - EXISTENTIAL_DEPOSIT
-            : BigInt(0);
-      } else {
-        amount = (TRANSFERABLE * BigInt(percent)) / BigInt(100);
-      }
-      const display = fromPlanck(amount.toString(), selectedDenom);
-      setDisplayValue(display);
-    },
-    [selectedDenom]
-  );
-
-  // ED warning
-  const showEdWarning = useMemo(() => {
-    if (!displayValue.trim()) return false;
-    const planck = toPlanck(displayValue, selectedDenom);
-    if (!planck) return false;
-    try {
-      const entered = BigInt(planck);
-      return TRANSFERABLE - entered < EXISTENTIAL_DEPOSIT && entered > BigInt(0);
-    } catch {
-      return false;
-    }
-  }, [displayValue, selectedDenom]);
-
-  const edDisplay = fromPlanck(EXISTENTIAL_DEPOSIT.toString(), selectedDenom);
-
-  const denomSelector = (
-    <Select value={selectedDenom.label} onValueChange={handleDenomChange}>
-      <SelectTrigger className="h-7 w-24 border-0 bg-muted/50 text-xs font-mono focus:ring-0 shadow-none">
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        {denominations.map((d) => (
-          <SelectItem key={d.label} value={d.label} className="text-xs font-mono">
-            {d.label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-
   return (
-    <div className="flex flex-col gap-2 w-full max-w-md">
-      <Label>Amount</Label>
-      <InputWithAddon
-        type="text"
-        inputMode={isPlanck ? "numeric" : "decimal"}
-        value={displayValue}
-        onChange={handleValueChange}
-        className="font-mono"
-        placeholder={isPlanck ? "0" : "0.00"}
-        suffix={denomSelector}
+    <div className="w-full max-w-md">
+      <Balance
+        name="value"
+        label="Amount"
+        client={null as any}
+        onChange={() => {}}
       />
-      <div className="flex items-center justify-between text-xs text-muted-foreground">
-        <span>Available: 15 {SYMBOL}</span>
-        <div className="flex gap-1">
-          {[25, 50, 75].map((pct) => (
-            <Button
-              key={pct}
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-5 px-2 text-xs"
-              onClick={() => handlePercentage(pct)}
-            >
-              {pct}%
-            </Button>
-          ))}
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-5 px-2 text-xs"
-            onClick={() => handlePercentage(100)}
-          >
-            Max
-          </Button>
-        </div>
-      </div>
-      {showEdWarning && (
-        <p className="text-xs text-yellow-600">
-          Amount would reap account (ED: {edDisplay} {selectedDenom.label})
-        </p>
-      )}
     </div>
   );
 }

--- a/components/docs/demos/composite-demos.tsx
+++ b/components/docs/demos/composite-demos.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import React from "react";
+import { Option } from "@/components/params/inputs/option";
+import { Vector } from "@/components/params/inputs/vector";
+import { Text } from "@/components/params/inputs/text";
+
+export function OptionDemo() {
+  return (
+    <div className="w-full max-w-md">
+      <Option
+        name="tip"
+        label="Tip"
+        client={null as any}
+        onChange={() => {}}
+      >
+        <Text
+          name="tip-value"
+          label="Tip value"
+          client={null as any}
+          onChange={() => {}}
+        />
+      </Option>
+    </div>
+  );
+}
+
+export function VectorDemo() {
+  return (
+    <div className="w-full max-w-md">
+      <Vector
+        name="remarks"
+        label="Remarks"
+        client={null as any}
+        onChange={() => {}}
+      >
+        <Text
+          name="item"
+          label="Item"
+          client={null as any}
+          onChange={() => {}}
+        />
+      </Vector>
+    </div>
+  );
+}

--- a/components/docs/demos/docs-selector-preview.tsx
+++ b/components/docs/demos/docs-selector-preview.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import React from "react";
+import { ClientProvider, useClient } from "@/context/client";
+import { usePalletContext } from "@/hooks/use-pallet-context";
+import { Loader2 } from "lucide-react";
+import type { ParamInputProps } from "@/components/params/types";
+
+interface DocsSelectorPreviewProps {
+  palletName: string;
+  children: React.ReactElement<ParamInputProps>;
+}
+
+function SelectorPreviewInner({
+  palletName,
+  children,
+}: DocsSelectorPreviewProps) {
+  const { client, loading: clientLoading } = useClient();
+  const { context, isLoading: contextLoading } = usePalletContext(
+    client,
+    palletName
+  );
+
+  const isConnecting = clientLoading;
+  const isLoadingData = !clientLoading && (contextLoading || (!context && !!client));
+
+  return (
+    <div className="relative w-full max-w-md">
+      <div className="absolute -top-8 right-0 flex items-center gap-1.5 text-xs text-muted-foreground">
+        {isConnecting ? (
+          <>
+            <Loader2 className="h-3 w-3 animate-spin" />
+            <span>Connecting to Polkadot...</span>
+          </>
+        ) : isLoadingData ? (
+          <>
+            <Loader2 className="h-3 w-3 animate-spin" />
+            <span>Loading data...</span>
+          </>
+        ) : context ? (
+          <>
+            <span className="h-2 w-2 rounded-full bg-green-500" />
+            <span>Polkadot</span>
+          </>
+        ) : (
+          <>
+            <span className="h-2 w-2 rounded-full bg-red-500" />
+            <span>Connection failed</span>
+          </>
+        )}
+      </div>
+      {React.cloneElement(children, {
+        client: client as any,
+        palletContext: context,
+        isContextLoading: clientLoading || contextLoading,
+      })}
+    </div>
+  );
+}
+
+export function DocsSelectorPreview({
+  palletName,
+  children,
+}: DocsSelectorPreviewProps) {
+  return (
+    <ClientProvider>
+      <SelectorPreviewInner palletName={palletName}>
+        {children}
+      </SelectorPreviewInner>
+    </ClientProvider>
+  );
+}

--- a/components/docs/demos/enum-demo.tsx
+++ b/components/docs/demos/enum-demo.tsx
@@ -1,75 +1,33 @@
 "use client";
 
-import React, { useState } from "react";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import React from "react";
+import { Enum } from "@/components/params/inputs/enum";
 
-interface DemoVariant {
-  name: string;
-  docs: string;
-}
-
-const VARIANTS: DemoVariant[] = [
+const DEMO_VARIANTS = [
   {
     name: "SuperMajorityApprove",
-    docs: "A supermajority of aye votes is required to pass this motion.",
+    docs: ["A supermajority of aye votes is required to pass this motion."],
   },
   {
     name: "SuperMajorityAgainst",
-    docs: "A supermajority of nay votes is required to reject this motion.",
+    docs: ["A supermajority of nay votes is required to reject this motion."],
   },
   {
     name: "SimpleMajority",
-    docs: "A simple majority of votes is required.",
+    docs: ["A simple majority of votes is required."],
   },
 ];
 
 export function EnumDemo() {
-  const [selected, setSelected] = useState(VARIANTS[0].name);
-
   return (
-    <div className="flex flex-col gap-2 w-full max-w-md">
-      <Label>Vote Threshold</Label>
-      <Select value={selected} onValueChange={setSelected}>
-        <SelectTrigger>
-          <SelectValue placeholder="Select variant" />
-        </SelectTrigger>
-        <SelectContent>
-          <TooltipProvider delayDuration={300}>
-            {VARIANTS.map((variant) => {
-              const item = (
-                <SelectItem key={variant.name} value={variant.name}>
-                  {variant.name}
-                </SelectItem>
-              );
-
-              return (
-                <Tooltip key={variant.name}>
-                  <TooltipTrigger asChild>{item}</TooltipTrigger>
-                  <TooltipContent side="right" className="max-w-xs text-xs">
-                    {variant.docs}
-                  </TooltipContent>
-                </Tooltip>
-              );
-            })}
-          </TooltipProvider>
-        </SelectContent>
-      </Select>
-      <p className="text-xs text-muted-foreground font-mono">
-        {"{"} type: &quot;{selected}&quot; {"}"}
-      </p>
+    <div className="w-full max-w-md">
+      <Enum
+        name="threshold"
+        label="Vote Threshold"
+        client={null as any}
+        variants={DEMO_VARIANTS}
+        onChange={() => {}}
+      />
     </div>
   );
 }

--- a/components/docs/demos/index.ts
+++ b/components/docs/demos/index.ts
@@ -1,3 +1,14 @@
 export { AccountDemo } from "./account-demo";
 export { BalanceDemo } from "./balance-demo";
 export { EnumDemo } from "./enum-demo";
+export { BoolDemo, TextDemo, HashDemo, BytesDemo, AmountDemo } from "./simple-demos";
+export { OptionDemo, VectorDemo } from "./composite-demos";
+export {
+  ValidatorSelectorDemo,
+  ValidatorMultiSelectorDemo,
+  PoolSelectorDemo,
+  EraSelectorDemo,
+  ReferendumSelectorDemo,
+  TrackSelectorDemo,
+  BountySelectorDemo,
+} from "./selector-demos";

--- a/components/docs/demos/selector-demos.tsx
+++ b/components/docs/demos/selector-demos.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import React from "react";
+import { DocsSelectorPreview } from "./docs-selector-preview";
+import { ValidatorSelector } from "@/components/params/selectors/validator-selector";
+import { ValidatorMultiSelector } from "@/components/params/selectors/validator-multi-selector";
+import { PoolSelector } from "@/components/params/selectors/pool-selector";
+import { EraSelector } from "@/components/params/selectors/era-selector";
+import { ReferendumSelector } from "@/components/params/selectors/referendum-selector";
+import { TrackSelector } from "@/components/params/selectors/track-selector";
+import { BountySelector } from "@/components/params/selectors/bounty-selector";
+
+export function ValidatorSelectorDemo() {
+  return (
+    <DocsSelectorPreview palletName="Staking">
+      <ValidatorSelector
+        name="target"
+        label="Validator"
+        client={null as any}
+        onChange={() => {}}
+      />
+    </DocsSelectorPreview>
+  );
+}
+
+export function ValidatorMultiSelectorDemo() {
+  return (
+    <DocsSelectorPreview palletName="Staking">
+      <ValidatorMultiSelector
+        name="targets"
+        label="Validators"
+        client={null as any}
+        onChange={() => {}}
+      />
+    </DocsSelectorPreview>
+  );
+}
+
+export function PoolSelectorDemo() {
+  return (
+    <DocsSelectorPreview palletName="NominationPools">
+      <PoolSelector
+        name="poolId"
+        label="Pool"
+        client={null as any}
+        onChange={() => {}}
+      />
+    </DocsSelectorPreview>
+  );
+}
+
+export function EraSelectorDemo() {
+  return (
+    <DocsSelectorPreview palletName="Staking">
+      <EraSelector
+        name="era"
+        label="Era"
+        client={null as any}
+        onChange={() => {}}
+      />
+    </DocsSelectorPreview>
+  );
+}
+
+export function ReferendumSelectorDemo() {
+  return (
+    <DocsSelectorPreview palletName="Referenda">
+      <ReferendumSelector
+        name="pollIndex"
+        label="Referendum"
+        client={null as any}
+        onChange={() => {}}
+      />
+    </DocsSelectorPreview>
+  );
+}
+
+export function TrackSelectorDemo() {
+  return (
+    <DocsSelectorPreview palletName="Referenda">
+      <TrackSelector
+        name="trackId"
+        label="Track"
+        client={null as any}
+        onChange={() => {}}
+      />
+    </DocsSelectorPreview>
+  );
+}
+
+export function BountySelectorDemo() {
+  return (
+    <DocsSelectorPreview palletName="Bounties">
+      <BountySelector
+        name="bountyId"
+        label="Bounty"
+        client={null as any}
+        onChange={() => {}}
+      />
+    </DocsSelectorPreview>
+  );
+}

--- a/components/docs/demos/simple-demos.tsx
+++ b/components/docs/demos/simple-demos.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import React from "react";
+import { Boolean } from "@/components/params/inputs/boolean";
+import { Text } from "@/components/params/inputs/text";
+import { Hash256 } from "@/components/params/inputs/hash";
+import { Bytes } from "@/components/params/inputs/bytes";
+import { Amount } from "@/components/params/inputs/amount";
+
+export function BoolDemo() {
+  return (
+    <div className="w-full max-w-md">
+      <Boolean
+        name="approve"
+        label="Approve Proposal"
+        client={null as any}
+        onChange={() => {}}
+      />
+    </div>
+  );
+}
+
+export function TextDemo() {
+  return (
+    <div className="w-full max-w-md">
+      <Text
+        name="remark"
+        label="Remark"
+        client={null as any}
+        onChange={() => {}}
+      />
+    </div>
+  );
+}
+
+export function HashDemo() {
+  return (
+    <div className="w-full max-w-md">
+      <Hash256
+        name="codeHash"
+        label="Code Hash"
+        client={null as any}
+        onChange={() => {}}
+      />
+    </div>
+  );
+}
+
+export function BytesDemo() {
+  return (
+    <div className="w-full max-w-md">
+      <Bytes
+        name="data"
+        label="Data"
+        client={null as any}
+        onChange={() => {}}
+      />
+    </div>
+  );
+}
+
+export function AmountDemo() {
+  return (
+    <div className="w-full max-w-md">
+      <Amount
+        name="value"
+        label="Value"
+        typeName="u32"
+        client={null as any}
+        onChange={() => {}}
+      />
+    </div>
+  );
+}

--- a/content/docs/components/amount-input.mdx
+++ b/content/docs/components/amount-input.mdx
@@ -3,6 +3,30 @@ title: Amount Input
 description: Numeric input for integer types with range validation and hex mode
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <AmountDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { Amount } from "@/components/params/inputs/amount";
+
+<Amount
+  name="weight"
+  label="Weight"
+  description="The dispatch weight"
+  typeName="u64"
+  client={client}
+  typeId={8}
+  isRequired
+  onChange={(value) => console.log("Value:", value)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Amount Input
 
 The Amount input provides a numeric field for entering integer values such as `u32`, `u64`, `u128`, and their signed and compact variants. It displays the valid range for the type, supports decimal and hexadecimal input modes for large integers, and offers denomination support for balance-like compact types like `Compact<u128>`.

--- a/content/docs/components/bool-input.mdx
+++ b/content/docs/components/bool-input.mdx
@@ -3,6 +3,28 @@ title: Bool Input
 description: Toggle switch for boolean parameters
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <BoolDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { Boolean } from "@/components/params/inputs/boolean";
+
+<Boolean
+  name="approve"
+  label="Approve"
+  description="Whether to approve the proposal"
+  client={client}
+  typeId={1}
+  onChange={(value) => console.log("Checked:", value)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Bool Input
 
 The Bool input renders a toggle switch for Substrate boolean parameters. It provides a simple on/off control that maps directly to SCALE `bool` encoding.

--- a/content/docs/components/bounty-selector.mdx
+++ b/content/docs/components/bounty-selector.mdx
@@ -3,6 +3,28 @@ title: Bounty Selector
 description: Searchable combobox for selecting a treasury bounty by index
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <BountySelectorDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { BountySelector } from "@/components/params/selectors/bounty-selector";
+
+<BountySelector
+  name="bountyId"
+  label="Bounty"
+  client={client}
+  palletContext={governanceContext}
+  isContextLoading={false}
+  onChange={(value) => console.log("Selected:", value)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Bounty Selector
 
 The Bounty Selector is a contextual selector that replaces the default numeric input when the extrinsic builder detects a `bounty_id` parameter in bounty-related calls. It displays a searchable combobox populated with live bounty data including titles, reward values, curator information, and status.

--- a/content/docs/components/bytes-input.mdx
+++ b/content/docs/components/bytes-input.mdx
@@ -3,6 +3,29 @@ title: Bytes Input
 description: Multi-mode byte array input with hex, text, JSON, Base64, and file upload
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <BytesDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { Bytes } from "@/components/params/inputs/bytes";
+
+<Bytes
+  name="data"
+  label="Data"
+  description="The raw byte payload"
+  client={client}
+  typeId={14}
+  isRequired
+  onChange={(hex) => console.log("Hex bytes:", hex)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Bytes Input
 
 The Bytes input provides a multi-mode editor for entering raw byte data. It supports five input modes -- hex, plain text, JSON, Base64, and file upload -- and automatically converts between them. All modes emit the same hex-encoded byte string to the parent form.

--- a/content/docs/components/era-selector.mdx
+++ b/content/docs/components/era-selector.mdx
@@ -3,6 +3,27 @@ title: Era Selector
 description: Numeric input with contextual hints showing current and active era
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <EraSelectorDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { EraSelector } from "@/components/params/selectors/era-selector";
+
+<EraSelector
+  name="era"
+  label="Era"
+  client={client}
+  palletContext={stakingContext}
+  onChange={(value) => console.log("Era:", value)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Era Selector
 
 The Era Selector is a contextual component that enhances a plain numeric input with live era information from the chain. Rather than replacing the input with a dropdown, it augments the field with a `ContextHint` showing the current and active era values, helping the user enter the correct era index.

--- a/content/docs/components/hash-input.mdx
+++ b/content/docs/components/hash-input.mdx
@@ -3,6 +3,29 @@ title: Hash Input
 description: Fixed-length hex hash input for H160, H256, and H512 types
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <HashDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { Hash256 } from "@/components/params/inputs/hash";
+
+<Hash256
+  name="codeHash"
+  label="Code Hash"
+  description="The hash of the contract code"
+  client={client}
+  typeId={11}
+  isRequired
+  onChange={(hash) => console.log("Hash:", hash)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Hash Input
 
 The Hash input provides a hex string field for fixed-length hash types. Three variants are exported -- `Hash160`, `Hash256`, and `Hash512` -- each validating against the expected byte length. A live validation icon shows whether the current value matches the required format.

--- a/content/docs/components/option-input.mdx
+++ b/content/docs/components/option-input.mdx
@@ -3,6 +3,28 @@ title: Option Input
 description: Toggle-based wrapper for Substrate Option<T> types with automatic inner type resolution
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <OptionDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { Option } from "@/components/params/inputs/option";
+
+<Option
+  name="tip"
+  label="Tip"
+  description="Optional tip for the block author"
+  client={client}
+  typeId={10}
+  onChange={(val) => console.log("Value:", val)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Option Input
 
 The Option input handles Substrate `Option<T>` types by presenting a toggle switch that lets the user choose between `None` (disabled) and `Some(value)` (enabled). When enabled, it automatically resolves and renders the appropriate sub-input for the inner type `T` using chain metadata. Options appear throughout Substrate pallets wherever a parameter is not strictly required -- tips, era selection, and optional configuration fields.

--- a/content/docs/components/pool-selector.mdx
+++ b/content/docs/components/pool-selector.mdx
@@ -3,6 +3,28 @@ title: Pool Selector
 description: Searchable combobox for selecting a nomination pool by ID
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <PoolSelectorDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { PoolSelector } from "@/components/params/selectors/pool-selector";
+
+<PoolSelector
+  name="poolId"
+  label="Pool"
+  client={client}
+  palletContext={stakingContext}
+  isContextLoading={false}
+  onChange={(value) => console.log("Selected:", value)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Pool Selector
 
 The Pool Selector is a contextual selector that replaces the default numeric input when the extrinsic builder detects a `pool_id` parameter in nomination pool calls. It displays a searchable combobox populated with live pool data including names, states, member counts, and total stake.

--- a/content/docs/components/referendum-selector.mdx
+++ b/content/docs/components/referendum-selector.mdx
@@ -3,6 +3,28 @@ title: Referendum Selector
 description: Searchable combobox for selecting an OpenGov referendum by index
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <ReferendumSelectorDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { ReferendumSelector } from "@/components/params/selectors/referendum-selector";
+
+<ReferendumSelector
+  name="pollIndex"
+  label="Referendum"
+  client={client}
+  palletContext={governanceContext}
+  isContextLoading={false}
+  onChange={(value) => console.log("Selected:", value)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Referendum Selector
 
 The Referendum Selector is a contextual selector that replaces the default numeric input when the extrinsic builder detects a parameter that expects a referendum index. It displays a searchable combobox with live referendum data including titles, track names, voting tallies, and status badges.

--- a/content/docs/components/text-input.mdx
+++ b/content/docs/components/text-input.mdx
@@ -3,6 +3,28 @@ title: Text Input
 description: Generic string input and fallback for unknown types
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <TextDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { Text } from "@/components/params/inputs/text";
+
+<Text
+  name="remark"
+  label="Remark"
+  description="An arbitrary string"
+  client={client}
+  typeId={10}
+  onChange={(value) => console.log("Text:", value)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Text Input
 
 The Text input is a plain string field that serves as the fallback component for any parameter type that does not match a more specific input in the registry. It accepts arbitrary text and emits it as a raw string.

--- a/content/docs/components/track-selector.mdx
+++ b/content/docs/components/track-selector.mdx
@@ -3,6 +3,28 @@ title: Track Selector
 description: Searchable combobox for selecting an OpenGov governance track
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <TrackSelectorDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { TrackSelector } from "@/components/params/selectors/track-selector";
+
+<TrackSelector
+  name="trackId"
+  label="Track"
+  client={client}
+  palletContext={governanceContext}
+  isContextLoading={false}
+  onChange={(value) => console.log("Selected:", value)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Track Selector
 
 The Track Selector is a contextual selector that replaces the default numeric input when the extrinsic builder detects a parameter that expects a governance track ID. It displays a searchable combobox populated with the chain's governance tracks, showing track names, IDs, and the current/maximum number of deciding referenda per track.

--- a/content/docs/components/validator-multi-selector.mdx
+++ b/content/docs/components/validator-multi-selector.mdx
@@ -3,6 +3,28 @@ title: Validator Multi-Selector
 description: Multi-select combobox for choosing up to 16 validators for staking nominations
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <ValidatorMultiSelectorDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { ValidatorMultiSelector } from "@/components/params/selectors/validator-multi-selector";
+
+<ValidatorMultiSelector
+  name="targets"
+  label="Validators"
+  client={client}
+  palletContext={stakingContext}
+  isContextLoading={false}
+  onChange={(value) => console.log("Selected:", value)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Validator Multi-Selector
 
 The Validator Multi-Selector is a contextual selector that replaces the default input when the extrinsic builder detects a parameter that expects a list of validator addresses. It provides a multi-select combobox with checkbox-style selection, removable chips for selected validators, and a cap of 16 nominations matching the Polkadot runtime limit.

--- a/content/docs/components/validator-selector.mdx
+++ b/content/docs/components/validator-selector.mdx
@@ -3,6 +3,28 @@ title: Validator Selector
 description: Searchable combobox for selecting a single validator from on-chain data
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <ValidatorSelectorDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { ValidatorSelector } from "@/components/params/selectors/validator-selector";
+
+<ValidatorSelector
+  name="target"
+  label="Validator"
+  client={client}
+  palletContext={stakingContext}
+  isContextLoading={false}
+  onChange={(value) => console.log("Selected:", value)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Validator Selector
 
 The Validator Selector is a contextual selector that replaces the default text input when the extrinsic builder detects a parameter that expects a single validator address. It displays a searchable combobox populated with live validator data including identity names, commission rates, and active/waiting status.

--- a/content/docs/components/vector-input.mdx
+++ b/content/docs/components/vector-input.mdx
@@ -3,6 +3,29 @@ title: Vector Input
 description: Dynamic-length list input for Substrate Vec<T> types with bulk entry support
 ---
 
+<Tabs items={["Preview", "Code"]}>
+<Tab value="Preview">
+<ComponentPreview>
+  <VectorDemo />
+</ComponentPreview>
+</Tab>
+<Tab value="Code">
+```tsx
+import { Vector } from "@/components/params/inputs/vector";
+
+<Vector
+  name="signatories"
+  label="Signatories"
+  description="List of signatory accounts"
+  client={client}
+  typeId={12}
+  minItems={2}
+  onChange={(val) => console.log("Items:", val)}
+/>
+```
+</Tab>
+</Tabs>
+
 # Vector Input
 
 The Vector input handles Substrate `Vec<T>` and `BoundedVec<T>` types by rendering a dynamic list of sub-inputs where items can be added, removed, and reordered. It supports both a form mode with individual item inputs and a bulk mode for pasting JSON arrays or line-separated values. Vectors are used extensively in Substrate for batch operations, multi-sig signatories, validator lists, and any parameter that accepts a variable-length collection.

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,7 +1,18 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
 import { ComponentPreview } from "@/components/docs/component-preview";
-import { AccountDemo, BalanceDemo, EnumDemo } from "@/components/docs/demos";
+import {
+  AccountDemo,
+  BalanceDemo,
+  EnumDemo,
+  BoolDemo,
+  TextDemo,
+  HashDemo,
+  BytesDemo,
+  AmountDemo,
+  OptionDemo,
+  VectorDemo,
+} from "@/components/docs/demos";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 export function useMDXComponents(components?: MDXComponents): MDXComponents {
@@ -11,6 +22,13 @@ export function useMDXComponents(components?: MDXComponents): MDXComponents {
     AccountDemo,
     BalanceDemo,
     EnumDemo,
+    BoolDemo,
+    TextDemo,
+    HashDemo,
+    BytesDemo,
+    AmountDemo,
+    OptionDemo,
+    VectorDemo,
     Tab,
     Tabs,
     ...components,


### PR DESCRIPTION
## Summary

- Adds interactive **Preview/Code tabs** to all 17 component documentation pages
- **Offline components** (Bool, Text, Hash, Bytes, Amount, Option, Vector, Account, Balance, Enum) render with `client={null}` — no chain connection needed
- **Selector components** (ValidatorSelector, ValidatorMultiSelector, PoolSelector, EraSelector, ReferendumSelector, TrackSelector, BountySelector) connect to Polkadot RPC via `DocsSelectorPreview` wrapper, fetching live on-chain data
- Chain status badge shows real-time connection state (Connecting → Loading → Polkadot)
- Refactors demo components into focused modules: `simple-demos`, `composite-demos`, `selector-demos`

## Test plan

- [ ] `yarn build` succeeds with no new warnings
- [ ] `yarn test` passes (259 tests)
- [ ] Visit each selector doc page and verify live data loads with green "Polkadot" badge
- [ ] Verify Preview/Code tab switching on all pages
- [ ] Verify dark mode and light mode rendering
- [ ] Open validator selector combobox — confirm identity names, commission rates, Active badges appear